### PR TITLE
feat: support for ServerURL in credential helpers

### DIFF
--- a/dockerconfig/load_benchmark_test.go
+++ b/dockerconfig/load_benchmark_test.go
@@ -89,10 +89,10 @@ func BenchmarkGetCredentials(b *testing.B) {
 		b.ResetTimer()
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			username, password, err := cfg.RegistryCredentialsForHostname("https://index.docker.io/v1/")
+			creds, err := cfg.RegistryCredentialsForHostname("https://index.docker.io/v1/")
 			require.NoError(b, err)
-			require.Equal(b, "testuser", username)
-			require.Equal(b, "testpassword", password)
+			require.Equal(b, "testuser", creds.Username)
+			require.Equal(b, "testpassword", creds.Password)
 		}
 	})
 
@@ -100,10 +100,10 @@ func BenchmarkGetCredentials(b *testing.B) {
 		b.ResetTimer()
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			username, password, err := cfg.RegistryCredentialsForHostname("https://registry.example.com")
+			creds, err := cfg.RegistryCredentialsForHostname("https://registry.example.com")
 			require.NoError(b, err)
-			require.Equal(b, "anotheruser", username)
-			require.Equal(b, "anotherpassword", password)
+			require.Equal(b, "anotheruser", creds.Username)
+			require.Equal(b, "anotherpassword", creds.Password)
 		}
 	})
 
@@ -111,10 +111,10 @@ func BenchmarkGetCredentials(b *testing.B) {
 		b.ResetTimer()
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			username, password, err := cfg.RegistryCredentialsForHostname("https://nonexistent.registry.com")
+			creds, err := cfg.RegistryCredentialsForHostname("https://nonexistent.registry.com")
 			require.NoError(b, err)
-			require.Empty(b, username)
-			require.Empty(b, password)
+			require.Empty(b, creds.Username)
+			require.Empty(b, creds.Password)
 		}
 	})
 
@@ -122,10 +122,10 @@ func BenchmarkGetCredentials(b *testing.B) {
 		b.ResetTimer()
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			username, password, err := RegistryCredentials("docker.io/library/nginx:latest")
+			creds, err := RegistryCredentials("docker.io/library/nginx:latest")
 			require.NoError(b, err)
-			require.Equal(b, "testuser", username)
-			require.Equal(b, "testpassword", password)
+			require.Equal(b, "testuser", creds.Username)
+			require.Equal(b, "testpassword", creds.Password)
 		}
 	})
 }

--- a/dockerimage/pull.go
+++ b/dockerimage/pull.go
@@ -26,13 +26,13 @@ type ImagePullClient interface {
 // See [dockerclient.IsPermanentClientError] for the list of non-permanent errors.
 // It first extracts the registry credentials from the image name, and sets them in the pull options.
 func Pull(ctx context.Context, imagePullCli ImagePullClient, imageName string, pullOpt image.PullOptions) error {
-	user, pwd, err := dockerconfig.RegistryCredentials(imageName)
+	creds, err := dockerconfig.RegistryCredentials(imageName)
 	if err != nil {
 		imagePullCli.Logger().Warn("failed to get image auth, setting empty credentials for the image", "image", imageName, "error", err)
 	} else {
 		authConfig := dockerconfig.AuthConfig{
-			Username: user,
-			Password: pwd,
+			Username: creds.Username,
+			Password: creds.Password,
 		}
 		encodedJSON, err := json.Marshal(authConfig)
 		if err != nil {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
Brings support for the Docker credential helper for GCloud
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
