### PR TITLE
fix: docker container log consumer race

### DIFF
--- a/dockercontainer/container.go
+++ b/dockercontainer/container.go
@@ -3,6 +3,7 @@ package dockercontainer
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/docker/go-sdk/dockerclient"
@@ -43,6 +44,8 @@ type Container struct {
 
 	// lifecycleHooks the lifecycle hooks to use for the container.
 	lifecycleHooks []LifecycleHooks
+
+	consumersMtx sync.Mutex // protects consumers
 
 	// consumers the log consumers to use for the container.
 	consumers []LogConsumer

--- a/dockercontainer/lifecycle.create.go
+++ b/dockercontainer/lifecycle.create.go
@@ -75,10 +75,7 @@ var defaultLogConsumersHook = func(cfg *LogConsumerConfig) LifecycleHooks {
 					return nil
 				}
 
-				c.consumers = c.consumers[:0]
-				for _, consumer := range cfg.Consumers {
-					c.followOutput(consumer)
-				}
+				c.resetConsumers(cfg.Consumers)
 
 				return c.startLogProduction(ctx, cfg.Opts...)
 			},


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It protects the log consummers from being accessed by different goroutines while updating them

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Reduce the data race caused by that code.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Follow-ups
I'd like to refactor the entire log-consumption feature, and build it from scratch
