### PR TITLE
chore(exec): remove uses of ExecOptions.Detach

### DIFF
--- a/container/exec/processor.go
+++ b/container/exec/processor.go
@@ -25,7 +25,6 @@ func NewProcessOptions(cmd []string) *ProcessOptions {
 	return &ProcessOptions{
 		ExecConfig: container.ExecOptions{
 			Cmd:          cmd,
-			Detach:       false,
 			AttachStdout: true,
 			AttachStderr: true,
 		},

--- a/container/exec/processor_test.go
+++ b/container/exec/processor_test.go
@@ -105,7 +105,6 @@ func TestNewProcessOptions(t *testing.T) {
 
 		require.NotNil(t, opts)
 		require.Equal(t, cmd, opts.ExecConfig.Cmd)
-		require.False(t, opts.ExecConfig.Detach)
 		require.True(t, opts.ExecConfig.AttachStdout)
 		require.True(t, opts.ExecConfig.AttachStderr)
 		require.Empty(t, opts.ExecConfig.User)
@@ -166,7 +165,6 @@ func TestProcessOptions(t *testing.T) {
 		WithTTY(true).Apply(opts)
 
 		// Verify defaults are still set
-		require.False(t, opts.ExecConfig.Detach)
 		require.True(t, opts.ExecConfig.AttachStdout)
 		require.True(t, opts.ExecConfig.AttachStderr)
 	})


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
See testcontainers/testcontainers-go#3211

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->
- testcontainers/testcontainers-go#3211

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
