### PR TITLE
fix: do not cleanup networks at the end of the benchmark

### DIFF
--- a/network/network_benchmark_test.go
+++ b/network/network_benchmark_test.go
@@ -17,8 +17,8 @@ func BenchmarkNetworkOperations(b *testing.B) {
 		b.ResetTimer()
 		for range b.N {
 			nw, err := network.New(ctx)
-			network.Cleanup(b, nw)
 			require.NoError(b, err)
+			require.NoError(b, nw.Terminate(ctx))
 		}
 	})
 
@@ -37,8 +37,8 @@ func BenchmarkNetworkOperations(b *testing.B) {
 		b.ResetTimer()
 		for range b.N {
 			nw, err := network.New(ctx, opts...)
-			network.Cleanup(b, nw)
 			require.NoError(b, err)
+			require.NoError(b, nw.Terminate(ctx))
 		}
 	})
 
@@ -90,7 +90,6 @@ func BenchmarkNetworkOperations(b *testing.B) {
 		b.ResetTimer()
 		for range b.N {
 			nw, err := network.New(ctx)
-			network.Cleanup(b, nw)
 			require.NoError(b, err)
 			require.NoError(b, nw.Terminate(ctx))
 		}
@@ -101,7 +100,6 @@ func BenchmarkNetworkOperations(b *testing.B) {
 		b.ResetTimer()
 		for range b.N {
 			nw, err := network.New(ctx)
-			network.Cleanup(b, nw)
 			require.NoError(b, err)
 			require.NoError(b, nw.Terminate(ctx))
 		}
@@ -118,8 +116,8 @@ func BenchmarkNetworkConcurrent(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				nw, err := network.New(ctx)
-				network.Cleanup(b, nw)
 				require.NoError(b, err)
+				require.NoError(b, nw.Terminate(ctx))
 			}
 		})
 	})


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It removes the network inside the benchmark loops
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The Docker daemon, specially on CI, runs out of available address pools to create new networks. This is common in integration or benchmark tests that rapidly create many networks without cleaning them up.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
