### PR TITLE
chore: simplify default loggin hook

### DIFF
--- a/container/container.run.go
+++ b/container/container.run.go
@@ -48,7 +48,7 @@ func Run(ctx context.Context, opts ...ContainerCustomizer) (*Container, error) {
 	}
 
 	defaultHooks := []LifecycleHooks{
-		DefaultLoggingHook(def.dockerClient.Logger()),
+		DefaultLoggingHook,
 	}
 
 	for _, is := range def.imageSubstitutors {

--- a/container/lifecycle.go
+++ b/container/lifecycle.go
@@ -3,7 +3,6 @@ package container
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"reflect"
 	"strings"
 	"time"
@@ -44,63 +43,61 @@ type DefinitionHook func(ctx context.Context, def *Definition) error
 type ContainerHook func(ctx context.Context, ctr *Container) error
 
 // DefaultLoggingHook is a hook that will log the container lifecycle events
-var DefaultLoggingHook = func(logger *slog.Logger) LifecycleHooks {
-	return LifecycleHooks{
-		PreCreates: []DefinitionHook{
-			func(_ context.Context, def *Definition) error {
-				logger.Info("Creating container", "image", def.image)
-				return nil
-			},
+var DefaultLoggingHook = LifecycleHooks{
+	PreCreates: []DefinitionHook{
+		func(_ context.Context, def *Definition) error {
+			def.dockerClient.Logger().Info("Creating container", "image", def.image)
+			return nil
 		},
-		PostCreates: []ContainerHook{
-			func(_ context.Context, c *Container) error {
-				logger.Info("Container created", "containerID", c.shortID)
-				return nil
-			},
+	},
+	PostCreates: []ContainerHook{
+		func(_ context.Context, c *Container) error {
+			c.logger.Info("Container created", "containerID", c.shortID)
+			return nil
 		},
-		PreStarts: []ContainerHook{
-			func(_ context.Context, c *Container) error {
-				logger.Info("Starting container", "containerID", c.shortID)
-				return nil
-			},
+	},
+	PreStarts: []ContainerHook{
+		func(_ context.Context, c *Container) error {
+			c.logger.Info("Starting container", "containerID", c.shortID)
+			return nil
 		},
-		PostStarts: []ContainerHook{
-			func(_ context.Context, c *Container) error {
-				logger.Info("Container started", "containerID", c.shortID)
-				return nil
-			},
+	},
+	PostStarts: []ContainerHook{
+		func(_ context.Context, c *Container) error {
+			c.logger.Info("Container started", "containerID", c.shortID)
+			return nil
 		},
-		PostReadies: []ContainerHook{
-			func(_ context.Context, c *Container) error {
-				logger.Info("Container is ready", "containerID", c.shortID)
-				return nil
-			},
+	},
+	PostReadies: []ContainerHook{
+		func(_ context.Context, c *Container) error {
+			c.logger.Info("Container is ready", "containerID", c.shortID)
+			return nil
 		},
-		PreStops: []ContainerHook{
-			func(_ context.Context, c *Container) error {
-				logger.Info("Stopping container", "containerID", c.shortID)
-				return nil
-			},
+	},
+	PreStops: []ContainerHook{
+		func(_ context.Context, c *Container) error {
+			c.logger.Info("Stopping container", "containerID", c.shortID)
+			return nil
 		},
-		PostStops: []ContainerHook{
-			func(_ context.Context, c *Container) error {
-				logger.Info("Container stopped", "containerID", c.shortID)
-				return nil
-			},
+	},
+	PostStops: []ContainerHook{
+		func(_ context.Context, c *Container) error {
+			c.logger.Info("Container stopped", "containerID", c.shortID)
+			return nil
 		},
-		PreTerminates: []ContainerHook{
-			func(_ context.Context, c *Container) error {
-				logger.Info("Terminating container", "containerID", c.shortID)
-				return nil
-			},
+	},
+	PreTerminates: []ContainerHook{
+		func(_ context.Context, c *Container) error {
+			c.logger.Info("Terminating container", "containerID", c.shortID)
+			return nil
 		},
-		PostTerminates: []ContainerHook{
-			func(_ context.Context, c *Container) error {
-				logger.Info("Container terminated", "containerID", c.shortID)
-				return nil
-			},
+	},
+	PostTerminates: []ContainerHook{
+		func(_ context.Context, c *Container) error {
+			c.logger.Info("Container terminated", "containerID", c.shortID)
+			return nil
 		},
-	}
+	},
 }
 
 // combineContainerHooks returns a [LifecycleHook] as the result

--- a/container/options_test.go
+++ b/container/options_test.go
@@ -284,7 +284,7 @@ func TestWithLabels(t *testing.T) {
 }
 
 func TestWithLifecycleHooks(t *testing.T) {
-	testHook := DefaultLoggingHook(nil)
+	testHook := DefaultLoggingHook
 
 	testLifecycleHooks := func(t *testing.T, replace bool, initial []LifecycleHooks, add []LifecycleHooks, expected []LifecycleHooks) {
 		t.Helper()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It changes the default logging hook, from a function receiving a logger to an instance. Each hook has access to the definition or the container, so they have access to the respective loggers.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Simpler code
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
