### PR TITLE
feat: copy dir to container

### DIFF
--- a/container/README.md
+++ b/container/README.md
@@ -48,6 +48,8 @@ It's possible to copy files to the container, and this can happen in different s
 - After the container is created but before it's started: using the `WithFiles` option, you can add files to the container.
 - After the container is started: using the container's `CopyToContainer` method, you can copy files to the container.
 
+If you need to copy a directory, you can use the `CopyDirToContainer` method, which uses the parent directory of the container path as the target directory.
+
 It's also possible to copy files from the container to the host, using the container's `CopyFromContainer` method.
 
 ## Defining the readiness state for the container

--- a/container/container.exec_test.go
+++ b/container/container.exec_test.go
@@ -15,6 +15,7 @@ import (
 const (
 	alpineLatest     = "alpine:latest"
 	nginxAlpineImage = "nginx:alpine"
+	bashImage        = "bash:5.2.26"
 )
 
 func TestContainer_Exec(t *testing.T) {

--- a/container/lifecycle.create.go
+++ b/container/lifecycle.create.go
@@ -45,7 +45,20 @@ var defaultCopyFileToContainerHook = func(files []File) LifecycleHooks {
 							return fmt.Errorf("read all: %w", err)
 						}
 					} else {
-						// no reader, read from host path
+						// no reader, read from host path, checking if it's a directory first
+						ok, err := isDir(f.HostPath)
+						if err != nil {
+							return err
+						}
+
+						if ok {
+							err := c.CopyDirToContainer(ctx, f.HostPath, f.ContainerPath, f.Mode)
+							if err != nil {
+								return fmt.Errorf("copy dir to container: %w", err)
+							}
+							continue
+						}
+
 						bs, err = os.ReadFile(f.HostPath)
 						if err != nil {
 							return fmt.Errorf("read file: %w", err)

--- a/container/testdata/waitForHello.sh
+++ b/container/testdata/waitForHello.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+file=/scripts/hello.sh
+
+until [ -s "$file" ]
+do
+    sleep 0.1
+done
+
+sh $file


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds the CopyDirToContainer method to the Container type, which allows tarring an entire dir by its host path, and passing the bytes to the container.

It uses the parent dir of the host path as base path in the container.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Copy files is not enough, as passing the bytes of an entire dir is not trivial.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
