### PR TITLE
feat: add container port methods

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -37,6 +37,11 @@ type Container struct {
 	isRunning bool
 }
 
+// DockerClient returns the docker client used by the container.
+func (c *Container) DockerClient() *client.Client {
+	return c.dockerClient
+}
+
 // ID returns the container ID
 func (c *Container) ID() string {
 	return c.containerID

--- a/container/container.run_test.go
+++ b/container/container.run_test.go
@@ -306,10 +306,24 @@ echo "done"
 			require.Equal(t, ctr.Image(), inspect.Config.Image)
 		})
 
-		t.Run("mapped-ports", func(t *testing.T) {
-			port1, err := ctr.MappedPort(context.Background(), "80/tcp")
+		t.Run("endpoint", func(t *testing.T) {
+			endpoint, err := ctr.Endpoint(context.Background(), "http")
 			require.NoError(t, err)
-			require.NotNil(t, port1)
+			require.True(t, strings.HasPrefix(endpoint, "http://"))
+			require.False(t, strings.HasSuffix(endpoint, ":80"))
+		})
+
+		t.Run("port-endpoint", func(t *testing.T) {
+			portEndpoint, err := ctr.PortEndpoint(context.Background(), "80/tcp", "tcp")
+			require.NoError(t, err)
+			require.True(t, strings.HasPrefix(portEndpoint, "tcp://"))
+		})
+
+		t.Run("mapped-port", func(t *testing.T) {
+			mappedPort, err := ctr.MappedPort(context.Background(), "80/tcp")
+			require.NoError(t, err)
+			require.NotNil(t, mappedPort)
+			require.NotEqual(t, "80", mappedPort.Port())
 		})
 
 		t.Run("state", func(t *testing.T) {

--- a/container/container.run_test.go
+++ b/container/container.run_test.go
@@ -803,11 +803,11 @@ func TestRunWithWaitStrategy(t *testing.T) {
 	})
 
 	t.Run("for-exit/success", func(t *testing.T) {
-		testRun(t, alpineLatest, wait.ForExit().WithExitTimeout(3*time.Second), false)
+		testRun(t, alpineLatest, wait.ForExit().WithTimeout(3*time.Second), false)
 	})
 
 	t.Run("for-exit/error", func(t *testing.T) {
-		testRun(t, nginxAlpineImage, wait.ForExit().WithExitTimeout(3*time.Second), true)
+		testRun(t, nginxAlpineImage, wait.ForExit().WithTimeout(3*time.Second), true)
 	})
 
 	t.Run("for-http", func(t *testing.T) {

--- a/container/ports.go
+++ b/container/ports.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Endpoint gets proto://host:port string for the lowest numbered exposed port
-// Will returns just host:port if proto is ""
+// Will return just host:port if proto is empty
 func (c *Container) Endpoint(ctx context.Context, proto string) (string, error) {
 	inspect, err := c.Inspect(ctx)
 	if err != nil {

--- a/container/ports.go
+++ b/container/ports.go
@@ -18,6 +18,10 @@ func (c *Container) Endpoint(ctx context.Context, proto string) (string, error) 
 		return "", err
 	}
 
+	if len(inspect.NetworkSettings.Ports) == 0 {
+		return "", errdefs.ErrNotFound.WithMessage("no ports exposed")
+	}
+
 	// Get lowest numbered bound port.
 	var lowestPort nat.Port
 	for port := range inspect.NetworkSettings.Ports {

--- a/container/ports.go
+++ b/container/ports.go
@@ -3,11 +3,53 @@ package container
 import (
 	"context"
 	"fmt"
+	"net"
 
 	"github.com/containerd/errdefs"
 
 	"github.com/docker/go-connections/nat"
 )
+
+// Endpoint gets proto://host:port string for the lowest numbered exposed port
+// Will returns just host:port if proto is ""
+func (c *Container) Endpoint(ctx context.Context, proto string) (string, error) {
+	inspect, err := c.Inspect(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	// Get lowest numbered bound port.
+	var lowestPort nat.Port
+	for port := range inspect.NetworkSettings.Ports {
+		if lowestPort == "" || port.Int() < lowestPort.Int() {
+			lowestPort = port
+		}
+	}
+
+	return c.PortEndpoint(ctx, lowestPort, proto)
+}
+
+// PortEndpoint gets proto://host:port string for the given exposed port
+// It returns proto://host:port or proto://[IPv6host]:port string for the given exposed port.
+// It returns just host:port or [IPv6host]:port if proto is blank.
+func (c *Container) PortEndpoint(ctx context.Context, port nat.Port, proto string) (string, error) {
+	host, err := c.Host(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	outerPort, err := c.MappedPort(ctx, port)
+	if err != nil {
+		return "", err
+	}
+
+	hostPort := net.JoinHostPort(host, outerPort.Port())
+	if proto == "" {
+		return hostPort, nil
+	}
+
+	return proto + "://" + hostPort, nil
+}
 
 // MappedPort gets externally mapped port for a container port
 func (c *Container) MappedPort(ctx context.Context, port nat.Port) (nat.Port, error) {

--- a/container/ports_benchmarks_test.go
+++ b/container/ports_benchmarks_test.go
@@ -1,0 +1,46 @@
+package container_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/go-sdk/container"
+)
+
+func BenchmarkPortEndpoint(b *testing.B) {
+	ctr, err := container.Run(context.Background(),
+		container.WithImage(nginxAlpineImage),
+	)
+	container.Cleanup(b, ctr)
+	require.NoError(b, err)
+	require.NotNil(b, ctr)
+
+	b.Run("port-endpoint", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := ctr.PortEndpoint(context.Background(), "80/tcp", "tcp")
+			require.NoError(b, err)
+		}
+	})
+
+	b.Run("mapped-port", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := ctr.MappedPort(context.Background(), "80/tcp")
+			require.NoError(b, err)
+		}
+	})
+
+	b.Run("endpoint", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := ctr.Endpoint(context.Background(), "tcp")
+			require.NoError(b, err)
+		}
+	})
+}

--- a/container/wait/exit.go
+++ b/container/wait/exit.go
@@ -32,8 +32,8 @@ func NewExitStrategy() *ExitStrategy {
 // since go has neither covariance nor generics, the return type must be the type of the concrete implementation
 // this is true for all properties, even the "shared" ones
 
-// WithExitTimeout can be used to change the default exit timeout
-func (ws *ExitStrategy) WithExitTimeout(exitTimeout time.Duration) *ExitStrategy {
+// WithTimeout can be used to change the default exit timeout
+func (ws *ExitStrategy) WithTimeout(exitTimeout time.Duration) *ExitStrategy {
 	ws.timeout = &exitTimeout
 	return ws
 }

--- a/container/wait/exit_test.go
+++ b/container/wait/exit_test.go
@@ -55,7 +55,7 @@ func TestWaitForExit(t *testing.T) {
 	target := exitStrategyTarget{
 		isRunning: false,
 	}
-	wg := NewExitStrategy().WithExitTimeout(100 * time.Millisecond)
+	wg := NewExitStrategy().WithTimeout(100 * time.Millisecond)
 	err := wg.WaitUntilReady(context.Background(), &target)
 	require.NoError(t, err)
 }

--- a/image/options.go
+++ b/image/options.go
@@ -30,7 +30,7 @@ func WithPullOptions(imagePullOptions image.PullOptions) PullOption {
 	}
 }
 
-// SaveOption is a function that configures the save options.
+// RemoveOption is a function that configures the remove options.
 type RemoveOption func(*removeOptions) error
 
 type removeOptions struct {


### PR DESCRIPTION
- **feat: add container port methods**
- **chore: expose the usage of the Docker client of the container**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds PortEndpoint and Endpoint container methods:

- Endpoint gives your the connection string for the lowest exposed port, using the given protocol
- PortEndpoint, the same as above, but also passing the exposed port

It adds tests and benchmarks for the new methods.

Finally, for convenience, we are exposing the underlying docker client, so that client code can call it without creating a new one.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Sugar on how to connect to a given container
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
