### PR TITLE
fix: use the next tag on release

### DIFF
--- a/.github/scripts/pre-release.sh
+++ b/.github/scripts/pre-release.sh
@@ -128,6 +128,9 @@ echo "Next tag: ${NEXT_TAG}"
 
 MODULES=$(go work edit -json | jq -r '.Use[] | "\(.DiskPath | ltrimstr("./"))"' | tr '\n' ' ' && echo)
 
+# Save the next tag for the module to a file so that the release script can use it
+execute_or_echo echo "${NEXT_vVERSION}" > "${ROOT_DIR}/.github/scripts/.${MODULE}-next-tag"
+
 for m in $MODULES; do
   if [[ "$DRY_RUN" == "true" ]]; then
     echo "[DRY RUN] Would update ${ROOT_DIR}/${m}/go.mod: ${GITHUB_REPO}/${MODULE} v${NEXT_VERSION}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.github/scripts/.*-next-tag
 coverage.out
 output.txt
 TEST-unit.xml

--- a/client/version.go
+++ b/client/version.go
@@ -1,7 +1,7 @@
 package client
 
 const (
-	version = "0.1.0-alpha006"
+	version = "0.1.0-alpha005"
 )
 
 // Version returns the version of the client package.

--- a/config/version.go
+++ b/config/version.go
@@ -1,7 +1,7 @@
 package config
 
 const (
-	version = "0.1.0-alpha006"
+	version = "0.1.0-alpha005"
 )
 
 // Version returns the version of the config package.

--- a/container/version.go
+++ b/container/version.go
@@ -1,7 +1,7 @@
 package container
 
 const (
-	version = "0.1.0-alpha006"
+	version = "0.1.0-alpha005"
 )
 
 // Version returns the version of the container package.

--- a/context/version.go
+++ b/context/version.go
@@ -1,7 +1,7 @@
 package context
 
 const (
-	version = "0.1.0-alpha006"
+	version = "0.1.0-alpha005"
 )
 
 // Version returns the version of the context package.

--- a/image/version.go
+++ b/image/version.go
@@ -1,7 +1,7 @@
 package image
 
 const (
-	version = "0.1.0-alpha006"
+	version = "0.1.0-alpha005"
 )
 
 // Version returns the version of the image package.

--- a/network/version.go
+++ b/network/version.go
@@ -1,7 +1,7 @@
 package network
 
 const (
-	version = "0.1.0-alpha006"
+	version = "0.1.0-alpha005"
 )
 
 // Version returns the version of the network package.


### PR DESCRIPTION
- **fix: use the next tag in the release script**
- **chore: revert version bump in go files**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It creates the git tag for the release of each module, and for that, each module will store the next requested bump in a temp file.

The release script will read it to avoid multiple calculations of the tag.

Finally, this PR reverts the bump in the version.go files

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Proper release automation
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->
- Caused by #49

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
