### PR TITLE
fix(container): strip headers from logs using log stream specification

### DIFF
--- a/container/container.logs.go
+++ b/container/container.logs.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/binary"
+	"errors"
 	"io"
 	"log/slog"
 
@@ -43,7 +44,7 @@ func (c *Container) Logs(ctx context.Context) (io.ReadCloser, error) {
 			// Read stream header
 			_, err := r.Read(header)
 			if err != nil {
-				if err != io.EOF {
+				if !errors.Is(err, io.EOF) {
 					pw.CloseWithError(err)
 				}
 				return
@@ -54,7 +55,7 @@ func (c *Container) Logs(ctx context.Context) (io.ReadCloser, error) {
 
 			// Copy frame data
 			if _, err := io.CopyN(pw, r, int64(frameSize)); err != nil {
-				if err != io.EOF {
+				if !errors.Is(err, io.EOF) {
 					pw.CloseWithError(err)
 				}
 				return

--- a/container/container.logs.go
+++ b/container/container.logs.go
@@ -20,8 +20,6 @@ func (c *Container) Logger() *slog.Logger {
 // Logs will fetch both STDOUT and STDERR from the current container. Returns a
 // ReadCloser and leaves it up to the caller to extract what it wants.
 func (c *Container) Logs(ctx context.Context) (io.ReadCloser, error) {
-	const streamHeaderSize = 8
-
 	options := container.LogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
@@ -31,6 +29,26 @@ func (c *Container) Logs(ctx context.Context) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Check if the container has TTY enabled, to determine the log format
+	inspect, err := c.Inspect(ctx)
+	if err != nil {
+		rc.Close()
+		return nil, fmt.Errorf("inspect container: %w", err)
+	}
+
+	// If TTY is enabled, logs are not multiplexed - return them directly
+	if inspect.Config.Tty {
+		return rc, nil
+	}
+
+	// TTY is disabled, logs are multiplexed with stream headers - parse them
+	return c.parseMultiplexedLogs(rc), nil
+}
+
+// parseMultiplexedLogs handles the multiplexed log format used when TTY is disabled
+func (c *Container) parseMultiplexedLogs(rc io.ReadCloser) io.ReadCloser {
+	const streamHeaderSize = 8
 
 	pr, pw := io.Pipe()
 	r := bufio.NewReader(rc)
@@ -57,7 +75,7 @@ func (c *Container) Logs(ctx context.Context) (io.ReadCloser, error) {
 			}
 		}()
 
-		// the Logs method processes the Docker stream format which includes:
+		// Process the Docker multiplexed stream format which includes:
 		// - Byte 0: Stream type (1 = stdout, 2 = stderr)
 		// - Bytes 1-3: Reserved
 		// - Bytes 4-7: Frame size (big-endian uint32)
@@ -81,7 +99,7 @@ func (c *Container) Logs(ctx context.Context) (io.ReadCloser, error) {
 		}
 	}()
 
-	return pr, nil
+	return pr
 }
 
 // printLogs is a helper function that will print the logs of a Docker container

--- a/container/container.logs.go
+++ b/container/container.logs.go
@@ -57,6 +57,10 @@ func (c *Container) Logs(ctx context.Context) (io.ReadCloser, error) {
 			}
 		}()
 
+		// the Logs method processes the Docker stream format which includes:
+		// - Byte 0: Stream type (1 = stdout, 2 = stderr)
+		// - Bytes 1-3: Reserved
+		// - Bytes 4-7: Frame size (big-endian uint32)
 		streamHeader := make([]byte, streamHeaderSize)
 
 		for {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
According to the log stream specification, the last 4 bytes of the header indicate the length of the log frame. There is an issue when a log message is exactly 10 character long, the header ends with \00\00\00\10. The current implementation uses ReadLine so it doesn't correctly read the header which results in the header being output. This is what the it looks like with the new test:

```
Error:      	Not equal: 
				expected: "abcdefghi\nfoo"
				actual  : "\x01\x00\x00\x00\x00\x00\x00\ni\nfoo"
				
				Diff:
				--- Expected
				+++ Actual
				@@ -1,2 +1,3 @@
				-abcdefghi
				+������
				+i
					foo
Test:       	TestContainerLogsShouldBeWithoutStreamHeader
```

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->
- Port of testcontainers/testcontainers-go#3226

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
