### PR TITLE
fix: use client's log when building images

### DIFF
--- a/image/build.go
+++ b/image/build.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -87,7 +86,6 @@ func Build(ctx context.Context, contextReader io.Reader, tag string, opts ...Bui
 	}
 
 	buildOpts := &buildOptions{
-		logWriter: os.Stdout,
 		opts: build.ImageBuildOptions{
 			Dockerfile: "Dockerfile",
 		},
@@ -154,7 +152,8 @@ func Build(ctx context.Context, contextReader io.Reader, tag string, opts ...Bui
 	}
 	defer resp.Body.Close()
 
-	output := buildOpts.logWriter
+	// use the bridge to log to the client logger
+	output := &loggerWriter{logger: buildOpts.buildClient.Logger()}
 
 	// Always process the output, even if it is not printed
 	// to ensure that errors during the build process are

--- a/image/build.go
+++ b/image/build.go
@@ -26,12 +26,12 @@ func ArchiveBuildContext(dir string, dockerfile string) (r io.Reader, err error)
 	// always pass context as absolute path
 	abs, err := filepath.Abs(dir)
 	if err != nil {
-		return nil, fmt.Errorf("error getting absolute path: %w", err)
+		return nil, fmt.Errorf("absolute path: %w", err)
 	}
 
 	dockerIgnoreExists, excluded, err := ParseDockerIgnore(abs)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse docker ignore: %w", err)
 	}
 
 	includes := []string{".", dockerfile}
@@ -45,7 +45,7 @@ func ArchiveBuildContext(dir string, dockerfile string) (r io.Reader, err error)
 		&archive.TarOptions{ExcludePatterns: excluded, IncludeFiles: includes},
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("tar with options: %w", err)
 	}
 
 	return buildContext, nil
@@ -64,7 +64,7 @@ type ImageBuildClient interface {
 func BuildFromDir(ctx context.Context, dir string, dockerfile string, tag string, opts ...BuildOption) (string, error) {
 	archive, err := ArchiveBuildContext(dir, dockerfile)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("archive build context: %w", err)
 	}
 
 	buildOpts := build.ImageBuildOptions{

--- a/image/build.log.go
+++ b/image/build.log.go
@@ -1,0 +1,39 @@
+package image
+
+import (
+	"encoding/json"
+	"log/slog"
+	"strings"
+
+	"github.com/docker/docker/pkg/jsonmessage"
+)
+
+// loggerWriter is a custom writer that forwards to the slog.Logger
+type loggerWriter struct {
+	logger *slog.Logger
+}
+
+// Write writes the message to the logger.
+func (lw *loggerWriter) Write(p []byte) (int, error) {
+	// Try to parse as JSON message first
+	var msg jsonmessage.JSONMessage
+	if err := json.Unmarshal(p, &msg); err == nil {
+		// It's a JSON message, log it structured and there is no default case because
+		// empty JSON messages should not be logged, to avoid noise.
+		switch {
+		case msg.Error != nil:
+			lw.logger.Error("Build error", "error", msg.Error.Message)
+		case msg.Stream != "":
+			lw.logger.Info(strings.TrimSuffix(msg.Stream, "\n"))
+		case msg.Status != "":
+			lw.logger.Info(msg.Status, "id", msg.ID, "progress", msg.Progress)
+		}
+	} else {
+		// Fall back to plain text
+		text := strings.TrimSuffix(string(p), "\n")
+		if text != "" {
+			lw.logger.Info(text)
+		}
+	}
+	return len(p), nil
+}

--- a/image/build.log_test.go
+++ b/image/build.log_test.go
@@ -1,0 +1,293 @@
+package image
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker/pkg/jsonmessage"
+)
+
+func TestLoggerWriter_Write(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		t.Run("json-message-with-error", func(t *testing.T) {
+			testLoggerWriterWithJSONError(t)
+		})
+
+		t.Run("json-message-with-stream", func(t *testing.T) {
+			testLoggerWriterWithJSONStream(t)
+		})
+
+		t.Run("json-message-with-status", func(t *testing.T) {
+			testLoggerWriterWithJSONStatus(t)
+		})
+
+		t.Run("plain-text-message", func(t *testing.T) {
+			testLoggerWriterWithPlainText(t)
+		})
+
+		t.Run("empty-message", func(t *testing.T) {
+			testLoggerWriterWithEmptyMessage(t)
+		})
+
+		t.Run("invalid-json-fallback", func(t *testing.T) {
+			testLoggerWriterWithInvalidJSON(t)
+		})
+
+		t.Run("stream-with-newline", func(t *testing.T) {
+			testLoggerWriterStreamWithNewline(t)
+		})
+
+		t.Run("status-with-progress", func(t *testing.T) {
+			testLoggerWriterStatusWithProgress(t)
+		})
+	})
+}
+
+func testLoggerWriterWithJSONError(t *testing.T) {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, nil))
+	writer := &loggerWriter{logger: logger}
+
+	errorMsg := jsonmessage.JSONMessage{
+		Error: &jsonmessage.JSONError{
+			Message: "build failed",
+		},
+	}
+	jsonData, err := json.Marshal(errorMsg)
+	require.NoError(t, err)
+
+	n, err := writer.Write(jsonData)
+	require.NoError(t, err)
+	require.Equal(t, len(jsonData), n)
+
+	logOutput := buf.String()
+	require.Contains(t, logOutput, "Build error")
+	require.Contains(t, logOutput, "build failed")
+	require.Contains(t, logOutput, "level=ERROR")
+}
+
+func testLoggerWriterWithJSONStream(t *testing.T) {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, nil))
+	writer := &loggerWriter{logger: logger}
+
+	streamMsg := jsonmessage.JSONMessage{
+		Stream: "Step 1/3 : FROM ubuntu:latest",
+	}
+	jsonData, err := json.Marshal(streamMsg)
+	require.NoError(t, err)
+
+	n, err := writer.Write(jsonData)
+	require.NoError(t, err)
+	require.Equal(t, len(jsonData), n)
+
+	logOutput := buf.String()
+	require.Contains(t, logOutput, "Step 1/3 : FROM ubuntu:latest")
+	require.Contains(t, logOutput, "level=INFO")
+}
+
+func testLoggerWriterWithJSONStatus(t *testing.T) {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, nil))
+	writer := &loggerWriter{logger: logger}
+
+	statusMsg := jsonmessage.JSONMessage{
+		Status: "Downloading",
+		ID:     "abc123",
+	}
+	jsonData, err := json.Marshal(statusMsg)
+	require.NoError(t, err)
+
+	n, err := writer.Write(jsonData)
+	require.NoError(t, err)
+	require.Equal(t, len(jsonData), n)
+
+	logOutput := buf.String()
+	require.Contains(t, logOutput, "Downloading")
+	require.Contains(t, logOutput, "id=abc123")
+	require.Contains(t, logOutput, "level=INFO")
+}
+
+func testLoggerWriterWithPlainText(t *testing.T) {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, nil))
+	writer := &loggerWriter{logger: logger}
+
+	plainText := "This is a plain text message"
+
+	n, err := writer.Write([]byte(plainText))
+	require.NoError(t, err)
+	require.Equal(t, len(plainText), n)
+
+	logOutput := buf.String()
+	require.Contains(t, logOutput, plainText)
+	require.Contains(t, logOutput, "level=INFO")
+}
+
+func testLoggerWriterWithEmptyMessage(t *testing.T) {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, nil))
+	writer := &loggerWriter{logger: logger}
+
+	n, err := writer.Write([]byte(""))
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+
+	logOutput := buf.String()
+	require.Empty(t, logOutput)
+}
+
+func testLoggerWriterWithInvalidJSON(t *testing.T) {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, nil))
+	writer := &loggerWriter{logger: logger}
+
+	invalidJSON := "{ invalid json"
+
+	n, err := writer.Write([]byte(invalidJSON))
+	require.NoError(t, err)
+	require.Equal(t, len(invalidJSON), n)
+
+	logOutput := buf.String()
+	require.Contains(t, logOutput, invalidJSON)
+	require.Contains(t, logOutput, "level=INFO")
+}
+
+func testLoggerWriterStreamWithNewline(t *testing.T) {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, nil))
+	writer := &loggerWriter{logger: logger}
+
+	streamMsg := jsonmessage.JSONMessage{
+		Stream: "Step 1/3 : FROM ubuntu:latest\n",
+	}
+	jsonData, err := json.Marshal(streamMsg)
+	require.NoError(t, err)
+
+	n, err := writer.Write(jsonData)
+	require.NoError(t, err)
+	require.Equal(t, len(jsonData), n)
+
+	logOutput := buf.String()
+	require.Contains(t, logOutput, "Step 1/3 : FROM ubuntu:latest")
+	require.NotContains(t, logOutput, "Step 1/3 : FROM ubuntu:latest\n")
+	require.Contains(t, logOutput, "level=INFO")
+}
+
+func testLoggerWriterStatusWithProgress(t *testing.T) {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, nil))
+	writer := &loggerWriter{logger: logger}
+
+	statusMsg := jsonmessage.JSONMessage{
+		Status:   "Downloading",
+		ID:       "abc123",
+		Progress: &jsonmessage.JSONProgress{Current: 1024, Total: 2048},
+	}
+	jsonData, err := json.Marshal(statusMsg)
+	require.NoError(t, err)
+
+	n, err := writer.Write(jsonData)
+	require.NoError(t, err)
+	require.Equal(t, len(jsonData), n)
+
+	logOutput := buf.String()
+	require.Contains(t, logOutput, "Downloading")
+	require.Contains(t, logOutput, "id=abc123")
+	require.Contains(t, logOutput, "progress=")
+	require.Contains(t, logOutput, "level=INFO")
+}
+
+func TestLoggerWriter_Write_EdgeCases(t *testing.T) {
+	t.Run("whitespace-only-message", func(t *testing.T) {
+		testLoggerWriterWithWhitespaceOnly(t)
+	})
+
+	t.Run("newline-only-message", func(t *testing.T) {
+		testLoggerWriterWithNewlineOnly(t)
+	})
+
+	t.Run("json-message-with-empty-fields", func(t *testing.T) {
+		testLoggerWriterWithEmptyJSONFields(t)
+	})
+}
+
+func testLoggerWriterWithWhitespaceOnly(t *testing.T) {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, nil))
+	writer := &loggerWriter{logger: logger}
+
+	whitespace := "   \t   "
+
+	n, err := writer.Write([]byte(whitespace))
+	require.NoError(t, err)
+	require.Equal(t, len(whitespace), n)
+
+	logOutput := buf.String()
+	require.Contains(t, logOutput, strings.TrimSpace(whitespace))
+	require.Contains(t, logOutput, "level=INFO")
+}
+
+func testLoggerWriterWithNewlineOnly(t *testing.T) {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, nil))
+	writer := &loggerWriter{logger: logger}
+
+	newlineOnly := "\n"
+
+	n, err := writer.Write([]byte(newlineOnly))
+	require.NoError(t, err)
+	require.Equal(t, len(newlineOnly), n)
+
+	logOutput := buf.String()
+	require.Empty(t, logOutput)
+}
+
+func testLoggerWriterWithEmptyJSONFields(t *testing.T) {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, nil))
+	writer := &loggerWriter{logger: logger}
+
+	emptyMsg := jsonmessage.JSONMessage{
+		Stream: "",
+		Status: "",
+		ID:     "",
+	}
+	jsonData, err := json.Marshal(emptyMsg)
+	require.NoError(t, err)
+
+	n, err := writer.Write(jsonData)
+	require.NoError(t, err)
+	require.Equal(t, len(jsonData), n)
+
+	// Should not log anything since all fields are empty
+	logOutput := buf.String()
+	require.Empty(t, logOutput)
+}

--- a/image/build_benchmarks_test.go
+++ b/image/build_benchmarks_test.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/go-sdk/client"
 	"github.com/docker/go-sdk/image"
 )
 
@@ -44,13 +46,19 @@ func BenchmarkBuild(b *testing.B) {
 	b.Run("from-dir", func(b *testing.B) {
 		buildPath := path.Join("testdata", "build")
 
+		// using a buffer to capture the build output
+		buf := &bytes.Buffer{}
+		logger := slog.New(slog.NewTextHandler(buf, nil))
+		cli, err := client.New(context.Background(), client.WithLogger(logger))
+		require.NoError(b, err)
+
 		b.ResetTimer()
 		b.ReportAllocs()
 
 		for i := range b.N {
 			// Use a unique tag for each iteration to avoid collisions
 			tag := fmt.Sprintf("test:benchmark-%d", i)
-			_, err := image.BuildFromDir(context.Background(), buildPath, "Dockerfile", tag, image.WithLogWriter(&bytes.Buffer{}))
+			_, err := image.BuildFromDir(context.Background(), buildPath, "Dockerfile", tag, image.WithBuildClient(cli))
 			require.NoError(b, err)
 
 			b.Cleanup(func() {

--- a/image/build_examples_test.go
+++ b/image/build_examples_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"path"
 
 	"github.com/docker/docker/api/types/build"
@@ -14,7 +15,11 @@ import (
 )
 
 func ExampleBuild() {
-	cli, err := client.New(context.Background())
+	// using a buffer to capture the build output
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, nil))
+
+	cli, err := client.New(context.Background(), client.WithLogger(logger))
 	if err != nil {
 		log.Println("error creating docker client", err)
 		return
@@ -34,15 +39,11 @@ func ExampleBuild() {
 		return
 	}
 
-	// using a buffer to capture the build output
-	buf := &bytes.Buffer{}
-
 	tag, err := image.Build(
 		context.Background(), contextArchive, "example:test",
 		image.WithBuildOptions(build.ImageBuildOptions{
 			Dockerfile: "Dockerfile",
 		}),
-		image.WithLogWriter(buf),
 	)
 	if err != nil {
 		log.Println("error building image", err)
@@ -65,7 +66,11 @@ func ExampleBuild() {
 }
 
 func ExampleBuildFromDir() {
-	cli, err := client.New(context.Background())
+	// using a buffer to capture the build output
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, nil))
+
+	cli, err := client.New(context.Background(), client.WithLogger(logger))
 	if err != nil {
 		log.Println("error creating docker client", err)
 		return
@@ -79,15 +84,11 @@ func ExampleBuildFromDir() {
 
 	buildPath := path.Join("testdata", "build")
 
-	// using a buffer to capture the build output
-	buf := &bytes.Buffer{}
-
 	tag, err := image.BuildFromDir(
 		context.Background(), buildPath, "Dockerfile", "example:test",
 		image.WithBuildOptions(build.ImageBuildOptions{
 			Dockerfile: "Dockerfile",
 		}),
-		image.WithLogWriter(buf),
 	)
 	if err != nil {
 		log.Println("error building image", err)

--- a/image/build_unit_test.go
+++ b/image/build_unit_test.go
@@ -19,8 +19,6 @@ func TestBuild_withRetries(t *testing.T) {
 	testBuild := func(t *testing.T, errReturned error, shouldRetry bool) {
 		t.Helper()
 
-		w := &bytes.Buffer{}
-
 		buf := &bytes.Buffer{}
 		m := &errMockCli{err: errReturned, logger: slog.New(slog.NewTextHandler(buf, nil))}
 
@@ -32,7 +30,7 @@ func TestBuild_withRetries(t *testing.T) {
 		defer cancel()
 		tag, err := Build(
 			ctx, contextArchive, "test",
-			WithBuildClient(m), WithLogWriter(w),
+			WithBuildClient(m),
 			WithBuildOptions(build.ImageBuildOptions{
 				Dockerfile: "Dockerfile",
 			}),

--- a/image/dockerignore.go
+++ b/image/dockerignore.go
@@ -17,7 +17,7 @@ func ParseDockerIgnore(targetDir string) (bool, []string, error) {
 	f, openErr := os.Open(fileLocation)
 	if openErr != nil {
 		if !os.IsNotExist(openErr) {
-			return false, nil, fmt.Errorf("error opening .dockerignore: %w", openErr)
+			return false, nil, fmt.Errorf("open .dockerignore: %w", openErr)
 		}
 		return false, nil, nil
 	}
@@ -27,7 +27,7 @@ func ParseDockerIgnore(targetDir string) (bool, []string, error) {
 	var err error
 	excluded, err = ignorefile.ReadAll(f)
 	if err != nil {
-		return true, excluded, fmt.Errorf("error reading .dockerignore: %w", err)
+		return true, excluded, fmt.Errorf("read .dockerignore: %w", err)
 	}
 
 	return exists, excluded, nil

--- a/image/options.go
+++ b/image/options.go
@@ -1,8 +1,6 @@
 package image
 
 import (
-	"io"
-
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/docker/docker/api/types/build"
@@ -14,7 +12,6 @@ type BuildOption func(*buildOptions) error
 
 type buildOptions struct {
 	buildClient ImageBuildClient
-	logWriter   io.Writer
 	opts        build.ImageBuildOptions
 }
 
@@ -22,14 +19,6 @@ type buildOptions struct {
 func WithBuildClient(buildClient ImageBuildClient) BuildOption {
 	return func(opts *buildOptions) error {
 		opts.buildClient = buildClient
-		return nil
-	}
-}
-
-// WithLogWriter sets the writer to write the build log to.
-func WithLogWriter(logWriter io.Writer) BuildOption {
-	return func(opts *buildOptions) error {
-		opts.logWriter = logWriter
 		return nil
 	}
 }


### PR DESCRIPTION
- **chore: proper error wrapping**
- **fix: use client's log for the build log**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It simplifies the logging og the built images, by just using the client logger instead.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Simpler code, that also does not pollutes client code's stdout.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

- Relates #54
<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
