### PR TITLE
chore: use distribution/registry as reference parser

### DIFF
--- a/config/auth/registry.go
+++ b/config/auth/registry.go
@@ -2,36 +2,13 @@ package auth
 
 import (
 	"fmt"
-	"regexp"
+
+	"github.com/distribution/reference"
 )
 
 const (
-	IndexDockerIO = "https://index.docker.io/v1/"
-
-	// Protocol part (optional)
-	protocolGroup = `(?:https?://)?`
-
-	// Hostname part (domain, IP, or localhost)
-	hostnameGroup = `(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}|(?:\d{1,3}\.){3}\d{1,3}|localhost)`
-
-	// Port part (optional)
-	portGroup = `(?::\d+)?`
-
-	// Registry part (must be a valid hostname/IP with optional protocol and port)
-	registryGroup = `(?:(?P<registry>` + protocolGroup + hostnameGroup + portGroup + `)/)?`
-
-	// Repository part (can be single or multi-level)
-	repositoryGroup = `(?P<repository>(?:[^/:@]+/)*[^/:@]+)`
-
-	// Tag part
-	tagGroup = `(?::(?P<tag>[^@]+))?`
-
-	// Digest part
-	digestGroup = `(?:@(?P<digest>sha256:[a-f0-9]{64}|sha512:[a-f0-9]{128}))?`
-
-	// 1. registry/repository[tag][digest]
-	// 2. repository[tag][digest] (when no registry)
-	regexImageRef = `^` + registryGroup + repositoryGroup + tagGroup + digestGroup + `$`
+	IndexDockerIO  = "https://index.docker.io/v1/"
+	DockerRegistry = "docker.io"
 )
 
 // ImageReference represents a parsed Docker image reference
@@ -46,64 +23,33 @@ type ImageReference struct {
 	Digest string
 }
 
-// ParseImageRef extracts the registry from the image name, using a regular expression to extract the registry from the image name.
-// - image:tag
-// - image:tag@digest
-// - image
-// - image@digest
-// - repository/image:tag
-// - repository/image:tag@digest
-// - repository/image
-// - repository/image@digest
-// - registry/image:tag
-// - registry/image:tag@digest
-// - registry/image
-// - registry/image@digest
-// - registry/repository/image:tag
-// - registry/repository/image:tag@digest
-// - registry/repository/image
-// - registry/repository/image@digest
-// - registry:port/repository/image:tag
-// - registry:port/repository/image:tag@digest
-// - registry:port/repository/image
-// - registry:port/repository/image@digest
-// - registry:port/image:tag
-// - registry:port/image:tag@digest
-// - registry:port/image
-// - registry:port/image@digest
-// Once extracted the registry, it is validated to return the Docker Index URL
-// if the registry is a valid Docker Index URL, otherwise it returns the registry as is.
+// ParseImageRef extracts the registry from the image name, using github.com/distribution/reference as a reference parser,
+// and returns the ImageReference struct.
 func ParseImageRef(imageRef string) (ImageReference, error) {
-	var ref ImageReference
-
-	r := regexp.MustCompile(regexImageRef)
-
-	matches := r.FindStringSubmatch(imageRef)
-	if len(matches) == 0 {
-		return ref, fmt.Errorf("invalid image reference: %s", imageRef)
+	ref, err := reference.ParseAnyReference(imageRef)
+	if err != nil {
+		return ImageReference{}, fmt.Errorf("parse image ref: %w", err)
 	}
 
-	// Get named groups
-	names := r.SubexpNames()
-	result := make(map[string]string)
-	for i, name := range names {
-		if i != 0 && name != "" { // Skip the first empty name
-			result[name] = matches[i]
-		}
+	imgRef := ImageReference{}
+
+	named, namedOk := ref.(reference.Named)
+	if namedOk {
+		imgRef.Registry = reference.Domain(named)
+		imgRef.Repository = reference.Path(named)
 	}
 
-	if result["registry"] == "" {
-		result["registry"] = IndexDockerIO
+	tagged, ok := ref.(reference.Tagged)
+	if ok {
+		imgRef.Tag = tagged.Tag()
 	}
 
-	ref = ImageReference{
-		Registry:   resolveRegistryHost(result["registry"]),
-		Repository: result["repository"],
-		Tag:        result["tag"],
-		Digest:     result["digest"],
+	digest, ok := ref.(reference.Digested)
+	if ok {
+		imgRef.Digest = string(digest.Digest())
 	}
 
-	return ref, nil
+	return imgRef, nil
 }
 
 // resolveRegistryHost can be used to transform a docker registry host name into what is used for the docker config/cred helpers

--- a/config/config.go
+++ b/config/config.go
@@ -197,7 +197,6 @@ func (c *Config) resolveFromCredentialHelper(helper, hostname string) (AuthConfi
 func (c *Config) processStoredAuthConfig(stored AuthConfig, hostname string) (AuthConfig, error) {
 	authConfig := AuthConfig{
 		Auth:          stored.Auth,
-		Email:         stored.Email,
 		IdentityToken: stored.IdentityToken,
 		Password:      stored.Password,
 		RegistryToken: stored.RegistryToken,

--- a/config/go.mod
+++ b/config/go.mod
@@ -2,11 +2,15 @@ module github.com/docker/go-sdk/config
 
 go 1.23.6
 
-require github.com/stretchr/testify v1.10.0
+require (
+	github.com/distribution/reference v0.6.0
+	github.com/stretchr/testify v1.10.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/config/go.sum
+++ b/config/go.sum
@@ -1,6 +1,8 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
+github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -8,6 +10,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/config/types.go
+++ b/config/types.go
@@ -60,15 +60,9 @@ type ProxyConfig struct {
 
 // AuthConfig contains authorization information for connecting to a Registry.
 type AuthConfig struct {
-	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
-	Auth     string `json:"auth,omitempty"`
-
-	// Email is an optional value associated with the username.
-	// This field is deprecated and will be removed in a later
-	// version of docker.
-	Email string `json:"email,omitempty"`
-
+	Username      string `json:"username,omitempty"`
+	Password      string `json:"password,omitempty"`
+	Auth          string `json:"auth,omitempty"`
 	ServerAddress string `json:"serveraddress,omitempty"`
 
 	// IdentityToken is used to authenticate the user and get

--- a/image/mocks_test.go
+++ b/image/mocks_test.go
@@ -44,5 +44,9 @@ func (f *errMockCli) Close() error {
 }
 
 func (f *errMockCli) Logger() *slog.Logger {
+	if f.logger == nil {
+		f.logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+
 	return f.logger
 }

--- a/image/pull.go
+++ b/image/pull.go
@@ -48,15 +48,15 @@ func Pull(ctx context.Context, imageName string, opts ...PullOption) error {
 		return errors.New("image name is not set")
 	}
 
-	ref, err := auth.ParseImageRef(imageName)
-	if err != nil {
-		return fmt.Errorf("parse image ref: %w", err)
-	}
-
 	authConfigs, err := config.AuthConfigs(imageName)
 	if err != nil {
 		pullOpts.pullClient.Logger().Warn("failed to get image auth, setting empty credentials for the image", "image", imageName, "error", err)
 	} else {
+		ref, err := auth.ParseImageRef(imageName)
+		if err != nil {
+			return fmt.Errorf("parse image ref: %w", err)
+		}
+
 		creds, ok := authConfigs[ref.Registry]
 		if !ok {
 			pullOpts.pullClient.Logger().Warn("no image auth found for image, setting empty credentials for the image. This is expected for public images", "image", imageName)


### PR DESCRIPTION
- **chore(config): remove deprecated field**
- **chore: use distribution/registry as image reference parser**
- **fix: extract registry only if needed**
- **fix: default logger in tests**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR removes the custom code to parse image references, and instead uses "`github.com/distribution/reference`", which is more complete for doing that task.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Reduce the code to maintain, using an already existing library, which is also the reference for image references.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
