### PR TITLE
feat(image): make pull handler configurable

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3,7 +3,6 @@ package client_test
 import (
 	"context"
 	"errors"
-	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -139,7 +138,7 @@ func TestNew(t *testing.T) {
 
 		t.Run("context-wins/found", func(t *testing.T) {
 			t.Setenv(dockercontext.EnvOverrideContext, dockercontext.DefaultContextName)
-			cli, err := client.New(context.Background())
+			cli, err := client.New(context.Background(), client.WithHealthCheck(noopHealthCheck))
 			require.NoError(t, err)
 			require.NotNil(t, cli)
 		})
@@ -147,7 +146,7 @@ func TestNew(t *testing.T) {
 		t.Run("context-wins/not-found", func(t *testing.T) {
 			t.Setenv(dockercontext.EnvOverrideContext, "foocontext") // this context does not exist
 			cli, err := client.New(context.Background())
-			require.ErrorIs(t, err, os.ErrNotExist)
+			require.Error(t, err)
 			require.Nil(t, cli)
 		})
 	})

--- a/image/README.md
+++ b/image/README.md
@@ -25,6 +25,7 @@ The Pull operation can be customized using functional options. The following opt
 
 - `WithPullClient(client *client.Client) image.PullOption`: The client to use to pull the image. If not provided, the default client will be used.
 - `WithPullOptions(options apiimage.PullOptions) image.PullOption`: The options to use to pull the image. The type of the options is "github.com/docker/docker/api/types/image".
+- `WithPullHandler(pullHandler func(r io.ReadCloser) error) image.PullOption`: The handler to use to pull the image, which acts as a callback to the pull operation.
 
 First, you need to import the following packages:
 
@@ -52,6 +53,10 @@ err = image.Pull(ctx,
     "nginx:alpine",
     image.WithPullClient(dockerClient),
     image.WithPullOptions(apiimage.PullOptions{}),
+    image.WithPullHandler(func(r io.ReadCloser) error {
+        // do something with the reader
+        return nil
+    }),
 )
 if err != nil {
     log.Fatalf("failed to pull image: %v", err)

--- a/image/options.go
+++ b/image/options.go
@@ -1,6 +1,9 @@
 package image
 
 import (
+	"errors"
+	"io"
+
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/docker/docker/api/types/build"
@@ -38,6 +41,7 @@ type PullOption func(*pullOptions) error
 type pullOptions struct {
 	pullClient  ImagePullClient
 	pullOptions image.PullOptions
+	pullHandler func(r io.ReadCloser) error
 }
 
 // WithPullClient sets the pull client used to pull the image.
@@ -52,6 +56,19 @@ func WithPullClient(pullClient ImagePullClient) PullOption {
 func WithPullOptions(imagePullOptions image.PullOptions) PullOption {
 	return func(opts *pullOptions) error {
 		opts.pullOptions = imagePullOptions
+		return nil
+	}
+}
+
+// WithPullHandler sets the pull handler function for the pull request.
+// Do not close the reader in the function, as it's done by the [Pull] function.
+func WithPullHandler(pullHandler func(r io.ReadCloser) error) PullOption {
+	return func(opts *pullOptions) error {
+		if pullHandler == nil {
+			return errors.New("pull handler is nil")
+		}
+
+		opts.pullHandler = pullHandler
 		return nil
 	}
 }

--- a/image/pull.go
+++ b/image/pull.go
@@ -18,10 +18,10 @@ import (
 )
 
 // defaultPullHandler is the default pull handler function.
-// It reads the reader and discards the content.
+// It downloads the entire docker image, and finishes at EOF of the pull request.
 // It's up to the caller to handle the io.ReadCloser and close it properly.
 var defaultPullHandler = func(r io.ReadCloser) error {
-	_, err := io.Copy(io.Discard, r)
+	_, err := io.ReadAll(r)
 	return err
 }
 

--- a/image/pull.go
+++ b/image/pull.go
@@ -17,6 +17,14 @@ import (
 	"github.com/docker/go-sdk/config/auth"
 )
 
+// defaultPullHandler is the default pull handler function.
+// It reads the reader and discards the content.
+// It's up to the caller to handle the io.ReadCloser and close it properly.
+var defaultPullHandler = func(r io.ReadCloser) error {
+	_, err := io.Copy(io.Discard, r)
+	return err
+}
+
 // ImagePullClient is a client that can pull images.
 type ImagePullClient interface {
 	ImageClient
@@ -29,8 +37,11 @@ type ImagePullClient interface {
 // See [client.IsPermanentClientError] for the list of non-permanent errors.
 // It first extracts the registry credentials from the image name, and sets them in the pull options.
 // It needs to be called with a valid image name, and optional pull  options, see [PullOption].
+// It's possible to override the default pull handler function by using the [WithPullHandler] option.
 func Pull(ctx context.Context, imageName string, opts ...PullOption) error {
-	pullOpts := &pullOptions{}
+	pullOpts := &pullOptions{
+		pullHandler: defaultPullHandler,
+	}
 	for _, opt := range opts {
 		if err := opt(pullOpts); err != nil {
 			return fmt.Errorf("apply pull option: %w", err)
@@ -97,7 +108,9 @@ func Pull(ctx context.Context, imageName string, opts ...PullOption) error {
 	}
 	defer pull.Close()
 
-	// download of docker image finishes at EOF of the pull request
-	_, err = io.ReadAll(pull)
+	if err := pullOpts.pullHandler(pull); err != nil {
+		return fmt.Errorf("pull handler: %w", err)
+	}
+
 	return err
 }

--- a/image/pull_examples_test.go
+++ b/image/pull_examples_test.go
@@ -1,9 +1,12 @@
 package image_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log"
+	"strings"
 
 	apiimage "github.com/docker/docker/api/types/image"
 	"github.com/docker/go-sdk/client"
@@ -46,4 +49,24 @@ func ExamplePull_withPullOptions() {
 
 	// Output:
 	// <nil>
+}
+
+func ExamplePull_withPullHandler() {
+	opts := apiimage.PullOptions{
+		Platform: "linux/amd64",
+	}
+
+	buff := &bytes.Buffer{}
+
+	err := image.Pull(context.Background(), "alpine:3.22", image.WithPullOptions(opts), image.WithPullHandler(func(r io.ReadCloser) error {
+		_, err := io.Copy(buff, r)
+		return err
+	}))
+
+	fmt.Println(err)
+	fmt.Println(strings.Contains(buff.String(), "Pulling from library/alpine"))
+
+	// Output:
+	// <nil>
+	// true
 }

--- a/image/pull_test.go
+++ b/image/pull_test.go
@@ -1,7 +1,10 @@
 package image_test
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,18 +14,25 @@ import (
 	"github.com/docker/go-sdk/image"
 )
 
+var noopShowProgress = func(_ io.ReadCloser) error {
+	return nil
+}
+
 func TestPull(t *testing.T) {
-	pull := func(t *testing.T, dockerClient *client.Client) {
+	pull := func(t *testing.T, dockerClient *client.Client, expectedErr error, opts ...image.PullOption) {
 		t.Helper()
+
+		opts = append(opts, image.WithPullClient(dockerClient))
+		opts = append(opts, image.WithPullOptions(apiimage.PullOptions{}))
 
 		ctx := context.Background()
 
-		err := image.Pull(ctx,
-			"nginx:alpine",
-			image.WithPullClient(dockerClient),
-			image.WithPullOptions(apiimage.PullOptions{}),
-		)
-		require.NoError(t, err)
+		err := image.Pull(ctx, "nginx:alpine", opts...)
+		if expectedErr != nil {
+			require.ErrorContains(t, err, expectedErr.Error())
+		} else {
+			require.NoError(t, err)
+		}
 	}
 
 	t.Run("new-client", func(t *testing.T) {
@@ -30,10 +40,46 @@ func TestPull(t *testing.T) {
 		require.NoError(t, err)
 		defer dockerClient.Close()
 
-		pull(t, dockerClient)
+		pull(t, dockerClient, nil)
 	})
 
 	t.Run("default-client", func(t *testing.T) {
-		pull(t, client.DefaultClient)
+		pull(t, client.DefaultClient, nil)
+	})
+
+	t.Run("pull-handler/nil", func(t *testing.T) {
+		cli, err := client.New(context.Background())
+		require.NoError(t, err)
+		defer cli.Close()
+
+		pull(t, cli, errors.New("pull handler is nil"), image.WithPullHandler(nil))
+	})
+
+	t.Run("pull-handler/noop", func(t *testing.T) {
+		cli, err := client.New(context.Background())
+		require.NoError(t, err)
+		defer cli.Close()
+
+		pull(t, cli, nil, image.WithPullHandler(noopShowProgress))
+	})
+
+	t.Run("pull-handler/custom", func(t *testing.T) {
+		cli, err := client.New(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, cli)
+
+		buf := &bytes.Buffer{}
+
+		pull(t, cli, nil, image.WithPullHandler(func(r io.ReadCloser) error {
+			_, err := io.Copy(buf, r)
+			defer func() {
+				if err := r.Close(); err != nil {
+					t.Logf("failed to close reader: %v", err)
+				}
+			}()
+			return err
+		}))
+
+		require.Contains(t, buf.String(), "Pulling from library/nginx")
 	})
 }


### PR DESCRIPTION
- **fix(client): update tests**
- **feat: make pull handler configurable**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a functional option to configure the Pull function and the returned Reader, so that it's possible to customise the handler for those bytes.

By default, the code will call `io.Copy(io.Discard, r)` for the returned reader, but client code can customise it with the new functional option.

Test, benchmarks and testable examples have been added, demonstrating how to use this new option.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Allow users of the image SDK to pull images and handle the response in the best way they need.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Follow-ups
Should this pattern be pushed down to the client's Pull option too?
