### PR TITLE
fix: update automation for proper releases

### DIFF
--- a/.github/scripts/pre-release.sh
+++ b/.github/scripts/pre-release.sh
@@ -68,9 +68,13 @@ echo "Latest tag: ${LATEST_TAG}"
 TAG_VERSION=$(echo "${LATEST_TAG}" | sed -E "s/^${MODULE}\///")
 echo "Tag version: ${TAG_VERSION}"
 
+# Strip leading zeros from the version before passing to semver-tool
+CLEAN_TAG_VERSION=$(echo "${TAG_VERSION}" | sed -E 's/alpha0+([0-9]+)/alpha\1/')
+echo "Clean tag version for semver-tool: ${CLEAN_TAG_VERSION}"
+
 # Get the version to bump to from the semver-tool and the bump type
-echo "Bumping ${BUMP_TYPE} version of ${LATEST_TAG}"
-BASE_VERSION=$(docker run --rm --platform=linux/amd64 "${DOCKER_IMAGE_SEMVER}" bump "${BUMP_TYPE}" "${TAG_VERSION}")
+echo "Bumping ${BUMP_TYPE} version of ${CLEAN_TAG_VERSION}"
+BASE_VERSION=$(docker run --rm --platform=linux/amd64 "${DOCKER_IMAGE_SEMVER}" bump "${BUMP_TYPE}" "${CLEAN_TAG_VERSION}")
 if [[ "${BASE_VERSION}" == "" ]]; then
   echo "Failed to bump the version. Please check the semver-tool image and the bump type."
   exit 1

--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -44,7 +44,13 @@ jobs:
             echo "No benchmarks found. Workflow completed successfully."
             echo "benchmarks_found=false" >> $GITHUB_OUTPUT
           else
-            echo "benchmarks_found=true" >> $GITHUB_OUTPUT
+            # Check if output indicates no test files
+            if grep -q "${{ inputs.project-directory }} \[no test files\]" output.txt; then
+              echo "No benchmark test files found for this module. Workflow completed successfully."
+              echo "benchmarks_found=false" >> $GITHUB_OUTPUT
+            else
+              echo "benchmarks_found=true" >> $GITHUB_OUTPUT
+            fi
           fi
 
       # NOTE: Benchmarks could change with different CPU types
@@ -87,7 +93,7 @@ jobs:
 
       - name: Store Benchmark Results for main branch
         uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20
-        if: ${{ steps.check-benchmarks.outputs.benchmarks_found == 'true' && github.ref_name == 'main' && steps.check-benchmarks.outputs.benchmarks_found == 'true' }}
+        if: ${{ github.ref_name == 'main' && steps.check-benchmarks.outputs.benchmarks_found == 'true' }}
         with:
           tool: 'go'
           output-file-path: ./${{ inputs.project-directory }}/output.txt

--- a/legacyadapters/version.go
+++ b/legacyadapters/version.go
@@ -1,7 +1,7 @@
 package legacyadapters
 
 const (
-	version = "0.1.0-alpha008"
+	version = "0.1.0-alpha001"
 )
 
 // Version returns the version of the legacyadapters package.

--- a/volume/version.go
+++ b/volume/version.go
@@ -1,0 +1,10 @@
+package volume
+
+const (
+	version = "0.1.0-alpha001"
+)
+
+// Version returns the version of the volume package.
+func Version() string {
+	return version
+}


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR fixes the following:

- version numbers in new modules: they must start in alpha001, because the automation looks up new git tags for them.
- avoids implicit conversion to octal numbers when calculating the next semver: because 008 and next are not valid octals, we need to clean them up.
- detects properly if no benchmarks were executed in a module 

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Storing benchmarks for a module without them was failing, because the output.txt file is still created although with invalid values.


<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
