### PR TITLE
fix: compare benchmarks with the last commit for a module

### DIFF
--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -59,11 +59,12 @@ jobs:
         uses: kenchan0130/actions-system-info@1a16c1960cecc14b8de80e3e11a42f3f9f037593 # v1.3
         id: system-info
 
-      - name: Get Main branch SHA
+      - name: Get latest SHA for ${{ inputs.project-directory }} in main
         if: ${{ steps.check-benchmarks.outputs.benchmarks_found == 'true' }}
         id: get-main-branch-sha
+        working-directory: ${{ inputs.project-directory }}
         run: |
-          SHA=$(git rev-parse origin/main)
+          SHA=$(git log -1 --format="%H" main -- .)
           echo "sha=$SHA" >> $GITHUB_OUTPUT
 
       - name: Get Benchmark Results from main branch


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It uses the last git commit for the modified module when calculating the SHA in main to get its benchmarks.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It could be the case that latest main's benchmark did not have a benchmark for a given module

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
