### PR TITLE
fix: use proper branch name

### DIFF
--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -64,7 +64,7 @@ jobs:
         id: get-main-branch-sha
         working-directory: ${{ inputs.project-directory }}
         run: |
-          SHA=$(git log -1 --format="%H" main -- .)
+          SHA=$(git log -1 --format="%H" origin/main -- .)
           echo "sha=$SHA" >> $GITHUB_OUTPUT
 
       - name: Get Benchmark Results from main branch


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It uses `origin/main` instead of `main`.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The CI script already uses `fetch-depth: 0`, which fetches all commit history and remote references. However, it doesn't create local branches, only remote tracking branches.
OTOH, "origin/main" refers to the remote tracking branch which is always available, and just "main" would refer to a local branch that doesn't exist in the CI environment.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->
- Caused by #72
<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
