### PR TITLE
fix: initial version for new modules

### DIFF
--- a/.github/scripts/pre-release.sh
+++ b/.github/scripts/pre-release.sh
@@ -59,7 +59,7 @@ fi
 
 LATEST_TAG=$(find_latest_tag "${MODULE}")
 if [[ -z "$LATEST_TAG" ]]; then
-  LATEST_TAG="${MODULE}/v0.1.0-alpha001"
+  LATEST_TAG="${MODULE}/v0.1.0-alpha000"
 fi
 
 echo "Latest tag: ${LATEST_TAG}"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It sets the initial version for modules without a git tag to 000, so that the first tag is created to 001.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
New modules would start with a new git tag 002, which is incorrect.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
