### PR TITLE
chore: consistency across modules

### DIFF
--- a/client/client.container.go
+++ b/client/client.container.go
@@ -21,6 +21,9 @@ func (c *Client) ContainerCreate(ctx context.Context, config *container.Config, 
 		return container.CreateResponse{}, fmt.Errorf("docker client: %w", err)
 	}
 
+	// Add the labels that identify this as a container created by the SDK.
+	AddSDKLabels(config.Labels)
+
 	return dockerClient.ContainerCreate(ctx, config, hostConfig, networkingConfig, platform, name)
 }
 

--- a/client/client.image.go
+++ b/client/client.image.go
@@ -22,6 +22,9 @@ func (c *Client) ImageBuild(ctx context.Context, options build.ImageBuildOptions
 		return build.ImageBuildResponse{}, errors.New("build context is nil")
 	}
 
+	// Add client labels
+	AddSDKLabels(options.Labels)
+
 	return dockerClient.ImageBuild(ctx, options.Context, options)
 }
 

--- a/client/client.network.go
+++ b/client/client.network.go
@@ -24,6 +24,9 @@ func (c *Client) NetworkCreate(ctx context.Context, name string, options network
 		return network.CreateResponse{}, fmt.Errorf("docker client: %w", err)
 	}
 
+	// Add the labels that identify this as a network created by the SDK.
+	AddSDKLabels(options.Labels)
+
 	return dockerClient.NetworkCreate(ctx, name, options)
 }
 

--- a/client/client.volume.go
+++ b/client/client.volume.go
@@ -14,6 +14,9 @@ func (c *Client) VolumeCreate(ctx context.Context, options volume.CreateOptions)
 		return volume.Volume{}, fmt.Errorf("docker client: %w", err)
 	}
 
+	// Add the labels that identify this as a volume created by the SDK.
+	AddSDKLabels(options.Labels)
+
 	return dockerClient.VolumeCreate(ctx, options)
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2,7 +2,6 @@ package client_test
 
 import (
 	"context"
-	"errors"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -85,19 +84,6 @@ func TestNew(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		cli, err := client.New(context.Background(), client.FromDockerOpt(dockerclient.WithHost("foobar")))
 		require.Error(t, err)
-		require.Nil(t, cli)
-	})
-
-	t.Run("error/apply-option", func(t *testing.T) {
-		// custom option that always fails to apply
-		customOpt := func() client.ClientOption {
-			return client.NewClientOption(func(_ *client.Client) error {
-				return errors.New("apply option")
-			})
-		}
-
-		cli, err := client.New(context.Background(), customOpt())
-		require.ErrorContains(t, err, "apply option")
 		require.Nil(t, cli)
 	})
 

--- a/client/client_unit_test.go
+++ b/client/client_unit_test.go
@@ -150,4 +150,17 @@ func TestNew_internal_state(t *testing.T) {
 		require.ErrorContains(t, err, "docker host from context")
 		require.Nil(t, client)
 	})
+
+	t.Run("error/apply-option", func(t *testing.T) {
+		// custom option that always fails to apply
+		customOpt := func() ClientOption {
+			return newClientOption(func(_ *Client) error {
+				return errors.New("apply option")
+			})
+		}
+
+		cli, err := New(context.Background(), customOpt())
+		require.ErrorContains(t, err, "apply option")
+		require.Nil(t, cli)
+	})
 }

--- a/client/labels.go
+++ b/client/labels.go
@@ -23,6 +23,9 @@ var sdkLabels = map[string]string{
 
 // AddSDKLabels adds the SDK labels to target.
 func AddSDKLabels(target map[string]string) {
+	if target == nil {
+		target = make(map[string]string)
+	}
 	maps.Copy(target, sdkLabels)
 }
 

--- a/client/labels.go
+++ b/client/labels.go
@@ -13,9 +13,9 @@ const (
 	LabelVersion = LabelBase + ".version"
 )
 
-// SDKLabels returns a map of labels that can be used to identify resources
+// sdkLabels is a map of labels that can be used to identify resources
 // created by this library.
-var SDKLabels = map[string]string{
+var sdkLabels = map[string]string{
 	LabelBase:    "true",
 	LabelLang:    "go",
 	LabelVersion: Version(),
@@ -23,5 +23,15 @@ var SDKLabels = map[string]string{
 
 // AddSDKLabels adds the SDK labels to target.
 func AddSDKLabels(target map[string]string) {
-	maps.Copy(target, SDKLabels)
+	maps.Copy(target, sdkLabels)
+}
+
+// SDKLabels returns a map of labels that can be used to identify resources
+// created by this library.
+func SDKLabels() map[string]string {
+	return map[string]string{
+		LabelBase:    "true",
+		LabelLang:    "go",
+		LabelVersion: Version(),
+	}
 }

--- a/client/labels_test.go
+++ b/client/labels_test.go
@@ -15,4 +15,14 @@ func TestAddSDKLabels(t *testing.T) {
 	require.Contains(t, labels, client.LabelBase)
 	require.Contains(t, labels, client.LabelLang)
 	require.Contains(t, labels, client.LabelVersion)
+
+	t.Run("idempotent", func(t *testing.T) {
+		sdkLabels := client.SDKLabels()
+		sdkLabels["foo"] = "bar"
+
+		labels := make(map[string]string)
+		client.AddSDKLabels(labels)
+		require.NotEqual(t, sdkLabels, labels)
+		require.NotContains(t, labels, "foo")
+	})
 }

--- a/client/options.go
+++ b/client/options.go
@@ -40,14 +40,14 @@ func (f funcOpt) Apply(c *Client) error {
 	return f(c)
 }
 
-// NewClientOption creates a new ClientOption from a function
-func NewClientOption(f func(*Client) error) ClientOption {
+// newClientOption creates a new ClientOption from a function
+func newClientOption(f func(*Client) error) ClientOption {
 	return funcOpt(f)
 }
 
 // WithDockerHost returns a client option that sets the docker host for the client.
 func WithDockerHost(dockerHost string) ClientOption {
-	return NewClientOption(func(c *Client) error {
+	return newClientOption(func(c *Client) error {
 		c.dockerHost = dockerHost
 		return nil
 	})
@@ -57,7 +57,7 @@ func WithDockerHost(dockerHost string) ClientOption {
 // If set, the client will use the docker context to determine the docker host.
 // If used in combination with [WithDockerHost], the host in the context will take precedence.
 func WithDockerContext(dockerContext string) ClientOption {
-	return NewClientOption(func(c *Client) error {
+	return newClientOption(func(c *Client) error {
 		c.dockerContext = dockerContext
 		return nil
 	})
@@ -65,7 +65,7 @@ func WithDockerContext(dockerContext string) ClientOption {
 
 // WithExtraHeaders returns a client option that sets the extra headers for the client.
 func WithExtraHeaders(headers map[string]string) ClientOption {
-	return NewClientOption(func(c *Client) error {
+	return newClientOption(func(c *Client) error {
 		c.extraHeaders = headers
 		return nil
 	})
@@ -75,7 +75,7 @@ func WithExtraHeaders(headers map[string]string) ClientOption {
 // If not set, the default health check will be used, which retries the ping to the
 // docker daemon until it is ready, three times, or the context is done.
 func WithHealthCheck(healthCheck func(ctx context.Context) func(c *Client) error) ClientOption {
-	return NewClientOption(func(c *Client) error {
+	return newClientOption(func(c *Client) error {
 		if healthCheck == nil {
 			return errors.New("health check is nil")
 		}
@@ -87,7 +87,7 @@ func WithHealthCheck(healthCheck func(ctx context.Context) func(c *Client) error
 
 // WithLogger returns a client option that sets the logger for the client.
 func WithLogger(log *slog.Logger) ClientOption {
-	return NewClientOption(func(c *Client) error {
+	return newClientOption(func(c *Client) error {
 		c.log = log
 		return nil
 	})

--- a/container/container.run.go
+++ b/container/container.run.go
@@ -99,14 +99,13 @@ func Run(ctx context.Context, opts ...ContainerCustomizer) (*Container, error) {
 		}
 	}
 
-	// Add the labels that identify this as a container created by the SDK.
-	client.AddSDKLabels(def.labels)
+	def.labels[moduleLabel] = Version()
 
 	dockerInput := &container.Config{
 		Entrypoint: def.entrypoint,
 		Image:      def.image,
 		Env:        env,
-		Labels:     def.labels,
+		Labels:     def.labels, // the Client will add the SDK labels automatically
 		Cmd:        def.cmd,
 	}
 

--- a/container/container.run_test.go
+++ b/container/container.run_test.go
@@ -406,6 +406,8 @@ func TestRun_addSDKLabels(t *testing.T) {
 	require.Contains(t, inspect.Config.Labels, client.LabelBase)
 	require.Contains(t, inspect.Config.Labels, client.LabelLang)
 	require.Contains(t, inspect.Config.Labels, client.LabelVersion)
+	require.Contains(t, inspect.Config.Labels, client.LabelBase+".container")
+	require.Equal(t, container.Version(), inspect.Config.Labels[client.LabelBase+".container"])
 }
 
 //go:embed testdata/hello.sh

--- a/container/version.go
+++ b/container/version.go
@@ -1,7 +1,10 @@
 package container
 
+import "github.com/docker/go-sdk/client"
+
 const (
-	version = "0.1.0-alpha009"
+	version     = "0.1.0-alpha009"
+	moduleLabel = client.LabelBase + ".container"
 )
 
 // Version returns the version of the container package.

--- a/image/build.go
+++ b/image/build.go
@@ -128,7 +128,7 @@ func Build(ctx context.Context, contextReader io.Reader, tag string, opts ...Bui
 	}
 
 	// Add client labels
-	client.AddSDKLabels(buildOpts.opts.Labels)
+	buildOpts.opts.Labels[moduleLabel] = Version()
 
 	// Close the context reader after all retries are complete
 	defer tryClose(contextReader)

--- a/image/version.go
+++ b/image/version.go
@@ -1,7 +1,10 @@
 package image
 
+import "github.com/docker/go-sdk/client"
+
 const (
-	version = "0.1.0-alpha009"
+	version     = "0.1.0-alpha009"
+	moduleLabel = client.LabelBase + ".image"
 )
 
 // Version returns the version of the image package.

--- a/network/README.md
+++ b/network/README.md
@@ -23,14 +23,14 @@ if err != nil {
 
 fmt.Printf("network: %+v", resp)
 
-inspect, err := network.GetByID(ctx, nw.ID())
+inspect, err := network.FindByID(ctx, nw.ID())
 if err != nil {
-    log.Fatalf("failed to get network by id: %v", err)
+    log.Fatalf("failed to find network by id: %v", err)
 }
 
-inspect, err = network.GetByName(ctx, nw.Name())
+inspect, err = network.FindByName(ctx, nw.Name())
 if err != nil {
-    log.Fatalf("failed to get network by name: %v", err)
+    log.Fatalf("failed to find network by name: %v", err)
 }
 
 _, err = network.List(ctx)

--- a/network/network.go
+++ b/network/network.go
@@ -30,7 +30,7 @@ func New(ctx context.Context, opts ...Option) (*Network, error) {
 		networkOptions.client = client.DefaultClient
 	}
 
-	client.AddSDKLabels(networkOptions.labels)
+	networkOptions.labels[moduleLabel] = Version()
 
 	nc := network.CreateOptions{
 		Driver:     networkOptions.driver,

--- a/network/network.inspect_test.go
+++ b/network/network.inspect_test.go
@@ -23,6 +23,12 @@ func TestInspect(t *testing.T) {
 		inspect, err := nw.Inspect(context.Background())
 		require.NoError(t, err)
 		require.NotNil(t, inspect)
+
+		require.Contains(t, inspect.Labels, client.LabelBase)
+		require.Contains(t, inspect.Labels, client.LabelLang)
+		require.Contains(t, inspect.Labels, client.LabelVersion)
+		require.Contains(t, inspect.Labels, client.LabelBase+".network")
+		require.Equal(t, network.Version(), inspect.Labels[client.LabelBase+".network"])
 	})
 
 	t.Run("network-does-not-exist", func(t *testing.T) {

--- a/network/network.list.go
+++ b/network/network.list.go
@@ -41,8 +41,8 @@ func WithFilters(filters filters.Args) ListOptions {
 	}
 }
 
-// GetByID returns a network by its ID.
-func GetByID(ctx context.Context, id string, opts ...ListOptions) (network.Inspect, error) {
+// FindByID returns a network by its ID.
+func FindByID(ctx context.Context, id string, opts ...ListOptions) (network.Inspect, error) {
 	opts = append(opts, WithFilters(filters.NewArgs(filters.Arg(filterByID, id))))
 
 	nws, err := list(ctx, opts...)
@@ -53,8 +53,8 @@ func GetByID(ctx context.Context, id string, opts ...ListOptions) (network.Inspe
 	return nws[0], nil
 }
 
-// GetByName returns a network by its name.
-func GetByName(ctx context.Context, name string, opts ...ListOptions) (network.Inspect, error) {
+// FindByName returns a network by its name.
+func FindByName(ctx context.Context, name string, opts ...ListOptions) (network.Inspect, error) {
 	opts = append(opts, WithFilters(filters.NewArgs(filters.Arg(filterByName, name))))
 
 	nws, err := list(ctx, opts...)

--- a/network/network.list_test.go
+++ b/network/network.list_test.go
@@ -10,30 +10,30 @@ import (
 	"github.com/docker/go-sdk/network"
 )
 
-func TestGetByID(t *testing.T) {
+func TestFindByID(t *testing.T) {
 	nw, err := network.New(context.Background(), network.WithName("test-by-id"))
 	network.Cleanup(t, nw)
 	require.NoError(t, err)
 
-	inspect, err := network.GetByID(context.Background(), nw.ID())
+	inspect, err := network.FindByID(context.Background(), nw.ID())
 	require.NoError(t, err)
 	require.Equal(t, nw.ID(), inspect.ID)
 
-	no, err := network.GetByID(context.Background(), "not-found-id")
+	no, err := network.FindByID(context.Background(), "not-found-id")
 	require.Error(t, err)
 	require.Empty(t, no.ID)
 }
 
-func TestGetByName(t *testing.T) {
+func TestFindByName(t *testing.T) {
 	nw, err := network.New(context.Background(), network.WithName("test-by-name"))
 	network.Cleanup(t, nw)
 	require.NoError(t, err)
 
-	inspect, err := network.GetByName(context.Background(), nw.Name())
+	inspect, err := network.FindByName(context.Background(), nw.Name())
 	require.NoError(t, err)
 	require.Equal(t, nw.Name(), inspect.Name)
 
-	no, err := network.GetByName(context.Background(), "not-found-name")
+	no, err := network.FindByName(context.Background(), "not-found-name")
 	require.Error(t, err)
 	require.Empty(t, no.Name)
 }

--- a/network/version.go
+++ b/network/version.go
@@ -1,7 +1,10 @@
 package network
 
+import "github.com/docker/go-sdk/client"
+
 const (
-	version = "0.1.0-alpha009"
+	version     = "0.1.0-alpha009"
+	moduleLabel = client.LabelBase + ".network"
 )
 
 // Version returns the version of the network package.

--- a/volume/version.go
+++ b/volume/version.go
@@ -1,7 +1,10 @@
 package volume
 
+import "github.com/docker/go-sdk/client"
+
 const (
-	version = "0.1.0-alpha001"
+	version     = "0.1.0-alpha009"
+	moduleLabel = client.LabelBase + ".volume"
 )
 
 // Version returns the version of the volume package.

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -26,7 +26,7 @@ func New(ctx context.Context, opts ...Option) (*Volume, error) {
 		volumeOptions.client = client.DefaultClient
 	}
 
-	client.AddSDKLabels(volumeOptions.labels)
+	volumeOptions.labels[moduleLabel] = Version()
 
 	v, err := volumeOptions.client.VolumeCreate(ctx, volume.CreateOptions{
 		Name:   volumeOptions.name,

--- a/volume/volume_test.go
+++ b/volume/volume_test.go
@@ -78,5 +78,11 @@ func TestNew(t *testing.T) {
 
 		labels := v.Labels
 		require.Equal(t, "bar", labels["foo"])
+
+		require.Contains(t, labels, client.LabelBase)
+		require.Contains(t, labels, client.LabelLang)
+		require.Contains(t, labels, client.LabelVersion)
+		require.Contains(t, labels, client.LabelBase+".volume")
+		require.Equal(t, volume.Version(), labels[client.LabelBase+".volume"])
 	})
 }


### PR DESCRIPTION
- **chore(client): do not expose NewClientOption**
- **chore: automatically add the SDK labels in the Create operations**
- **fix(client): do not allow altering the SDK labels**
- **chore(network): rename for consistency**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It does the following:

- client: makes the SDK labels not modifiable by client code
- client: does not expose the ability to create new client options
- client: automatically add SDK labels in the create operations
- container: add specific label with container module's version (com.docker.sdk.container=1.0.0)
- volume: add specific label with volume module's version (com.docker.sdk.volume=1.0.0)
- image: add specific label with image module's version (com.docker.sdk.image=1.0.0)
- network: add specific label with network module's version (com.docker.sdk.network=1.0.0)
- network: rename Get methods to Find

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Consistency

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
