### PR TITLE
chore: refinements in container lifecycle hooks

### DIFF
--- a/client/labels.go
+++ b/client/labels.go
@@ -3,14 +3,14 @@ package client
 import "maps"
 
 const (
-	// LabelBase is the base label for all Docker labels.
+	// LabelBase is the base label for all Docker SDK labels.
 	LabelBase = "com.docker.sdk"
 
-	// LabelLang specifies the language which created the container.
+	// LabelLang specifies the language.
 	LabelLang = LabelBase + ".lang"
 
-	// LabelVersion specifies the version of go-sdk which created the container.
-	LabelVersion = LabelBase + ".version"
+	// LabelVersion specifies the version of go-sdk's client.
+	LabelVersion = LabelBase + ".client"
 )
 
 // sdkLabels is a map of labels that can be used to identify resources

--- a/container/container.run.go
+++ b/container/container.run.go
@@ -2,16 +2,12 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/containerd/errdefs"
-	"github.com/containerd/platforms"
-
 	"github.com/docker/docker/api/types/container"
-	apiimage "github.com/docker/docker/api/types/image"
 	apinetwork "github.com/docker/docker/api/types/network"
 	"github.com/docker/go-sdk/client"
-	"github.com/docker/go-sdk/image"
 )
 
 // Run is a convenience function that creates a new container and starts it.
@@ -21,6 +17,17 @@ func Run(ctx context.Context, opts ...ContainerCustomizer) (*Container, error) {
 	def := Definition{
 		env:     make(map[string]string),
 		started: true,
+	}
+
+	// initialize the validate functions with the default ones
+	def.validateFuncs = []func() error{
+		func() error {
+			if def.image == "" {
+				return errors.New("image is required")
+			}
+			return nil
+		},
+		def.validateMounts,
 	}
 
 	for _, opt := range opts {
@@ -63,42 +70,6 @@ func Run(ctx context.Context, opts ...ContainerCustomizer) (*Container, error) {
 		}
 	}
 
-	var platform *platforms.Platform
-
-	if def.imagePlatform != "" {
-		p, err := platforms.Parse(def.imagePlatform)
-		if err != nil {
-			return nil, fmt.Errorf("invalid platform %s: %w", def.imagePlatform, err)
-		}
-		platform = &p
-	}
-
-	var shouldPullImage bool
-
-	if def.alwaysPullImage {
-		shouldPullImage = true // If requested always attempt to pull image
-	} else {
-		img, err := def.dockerClient.ImageInspect(ctx, def.image)
-		if err != nil {
-			if !errdefs.IsNotFound(err) {
-				return nil, err
-			}
-			shouldPullImage = true
-		}
-		if platform != nil && (img.Architecture != platform.Architecture || img.Os != platform.OS) {
-			shouldPullImage = true
-		}
-	}
-
-	if shouldPullImage {
-		pullOpt := apiimage.PullOptions{
-			Platform: def.imagePlatform, // may be empty
-		}
-		if err := image.Pull(ctx, def.image, image.WithPullClient(def.dockerClient), image.WithPullOptions(pullOpt)); err != nil {
-			return nil, err
-		}
-	}
-
 	def.labels[moduleLabel] = Version()
 
 	dockerInput := &container.Config{
@@ -131,7 +102,7 @@ func Run(ctx context.Context, opts ...ContainerCustomizer) (*Container, error) {
 		return nil, err
 	}
 
-	resp, err := def.dockerClient.ContainerCreate(ctx, dockerInput, hostConfig, networkingConfig, platform, def.name)
+	resp, err := def.dockerClient.ContainerCreate(ctx, dockerInput, hostConfig, networkingConfig, def.platform, def.name)
 	if err != nil {
 		return nil, fmt.Errorf("container create: %w", err)
 	}

--- a/container/definition.go
+++ b/container/definition.go
@@ -112,6 +112,20 @@ func (d *Definition) Image() string {
 	return d.image
 }
 
+// ImageSubstitutors returns the image substitutors used by the definition.
+func (d *Definition) ImageSubstitutors() []ImageSubstitutor {
+	return d.imageSubstitutors
+}
+
+// Labels returns the labels used by the definition.
+func (d *Definition) Labels() map[string]string {
+	if d.labels == nil {
+		d.labels = make(map[string]string)
+	}
+
+	return d.labels
+}
+
 // Name returns the name of the container.
 func (d *Definition) Name() string {
 	return d.name

--- a/container/definition.go
+++ b/container/definition.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/containerd/platforms"
+
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/go-sdk/client"

--- a/container/definition.go
+++ b/container/definition.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/containerd/platforms"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/go-sdk/client"
@@ -45,6 +46,9 @@ type Definition struct {
 	// hostConfigModifier the modifier for the host config before container creation
 	hostConfigModifier func(*container.HostConfig)
 
+	// validateFuncs the functions to validate the definition.
+	validateFuncs []func() error
+
 	// imageSubstitutors the image substitutors to use for the container.
 	imageSubstitutors []ImageSubstitutor
 
@@ -72,6 +76,10 @@ type Definition struct {
 	// imagePlatform the platform of the image
 	imagePlatform string
 
+	// platform the platform of the container.
+	// Used to override the platform of the image when building the container.
+	platform *platforms.Platform
+
 	// name the name of the container.
 	name string
 
@@ -84,15 +92,14 @@ type Definition struct {
 
 // validate validates the definition.
 func (d *Definition) validate() error {
-	if d.image == "" {
-		return errors.New("image is required")
+	var errs []error
+	for _, fn := range d.validateFuncs {
+		if err := fn(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
-	if err := d.validateMounts(); err != nil {
-		return fmt.Errorf("validate mounts: %w", err)
-	}
-
-	return nil
+	return errors.Join(errs...)
 }
 
 // DockerClient returns the docker client used by the definition.

--- a/container/lifecycle.go
+++ b/container/lifecycle.go
@@ -3,14 +3,19 @@ package container
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"reflect"
 	"strings"
 	"time"
 
+	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
+	apiimage "github.com/docker/docker/api/types/image"
 	"github.com/docker/go-sdk/container/exec"
 	"github.com/docker/go-sdk/container/wait"
+	"github.com/docker/go-sdk/image"
 )
 
 type LifecycleHooks struct {
@@ -188,6 +193,10 @@ func combineContainerHooks(defaultHooks, userDefinedHooks []LifecycleHooks) Life
 		}
 	}
 
+	// Always append the default pull hook after any other pre-create hook.
+	// User could have defined a build hook in which the image has not been defined yet.
+	hooks.PreCreates = append(hooks.PreCreates, defaultPullHook...)
+
 	return hooks
 }
 
@@ -257,4 +266,49 @@ func (c *Container) applyLifecycleHooks(ctx context.Context, logError bool, hook
 	}
 
 	return nil
+}
+
+// defaultPullHook is a hook that will pull the image if it is not present or if the platform is different.
+// It must be used as a [DefinitionHook] and not as a [ContainerHook] because it needs to be executed before the container is created.
+var defaultPullHook = []DefinitionHook{
+	func(ctx context.Context, def *Definition) error {
+		var platform *platforms.Platform
+
+		if def.imagePlatform != "" {
+			p, err := platforms.Parse(def.imagePlatform)
+			if err != nil {
+				return fmt.Errorf("invalid platform %s: %w", def.imagePlatform, err)
+			}
+			platform = &p
+			def.platform = platform
+		}
+
+		var shouldPullImage bool
+
+		if def.alwaysPullImage {
+			shouldPullImage = true // If requested always attempt to pull image
+		} else {
+			img, err := def.dockerClient.ImageInspect(ctx, def.image)
+			if err != nil {
+				if !errdefs.IsNotFound(err) {
+					return err
+				}
+				shouldPullImage = true
+			}
+			if platform != nil && (img.Architecture != platform.Architecture || img.Os != platform.OS) {
+				shouldPullImage = true
+			}
+		}
+
+		if shouldPullImage {
+			pullOpt := apiimage.PullOptions{
+				Platform: def.imagePlatform, // may be empty
+			}
+			if err := image.Pull(ctx, def.image, image.WithPullClient(def.dockerClient), image.WithPullOptions(pullOpt)); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
 }

--- a/container/lifecycle.go
+++ b/container/lifecycle.go
@@ -211,13 +211,13 @@ func applyContainerHooks(ctx context.Context, hooks []ContainerHook, ctr *Contai
 }
 
 func applyDefinitionHooks(ctx context.Context, hooks []DefinitionHook, def *Definition) error {
-	var errs []error
 	for _, hook := range hooks {
 		if err := hook(ctx, def); err != nil {
-			errs = append(errs, err)
+			return fmt.Errorf("apply definition hook: %w", err)
 		}
 	}
-	return errors.Join(errs...)
+
+	return nil
 }
 
 // applyLifecycleHooks calls hook on all LifecycleHooks.

--- a/container/lifecycle.go
+++ b/container/lifecycle.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
+
 	apiimage "github.com/docker/docker/api/types/image"
 	"github.com/docker/go-sdk/container/exec"
 	"github.com/docker/go-sdk/container/wait"

--- a/container/lifecycle_test.go
+++ b/container/lifecycle_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/go-sdk/client"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/go-sdk/client"
 )
 
 func TestCombineLifecycleHooks(t *testing.T) {

--- a/container/lifecycle_test.go
+++ b/container/lifecycle_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/go-sdk/client"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,7 +52,16 @@ func TestCombineLifecycleHooks(t *testing.T) {
 	// call all the hooks in the right order, honouring the lifecycle
 
 	def := Definition{
+		image:          nginxAlpineImage,
 		lifecycleHooks: []LifecycleHooks{combineContainerHooks(defaultHooks, userDefinedHooks)},
+		// define a docker client to avoid the need to initialize the client
+		dockerClient: client.DefaultClient,
+		// avoid validation errors
+		validateFuncs: []func() error{
+			func() error {
+				return nil
+			},
+		},
 	}
 	err := def.creatingHook(context.Background())
 	require.NoError(t, err)

--- a/container/options.go
+++ b/container/options.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
@@ -364,6 +365,49 @@ func WithAdditionalLifecycleHooks(hooks ...LifecycleHooks) CustomizeDefinitionOp
 func WithFiles(files ...File) CustomizeDefinitionOption {
 	return func(def *Definition) error {
 		def.files = append(def.files, files...)
+		return nil
+	}
+}
+
+// WithValidateFuncs sets the validate functions for a container.
+// By default, the container is validated using the following functions:
+// - an image is required
+// - mounts are validated
+// The validate functions are executed in the order they are added.
+// If one of the functions returns an error, the container is not created.
+// If no validate functions are provided, the container is validated using the default functions.
+func WithValidateFuncs(fn ...func() error) CustomizeDefinitionOption {
+	return func(def *Definition) error {
+		if fn == nil || slices.ContainsFunc(fn, func(fn func() error) bool {
+			return fn == nil
+		}) {
+			return errors.New("validate function is nil")
+		}
+
+		// override the default validate functions with the user-defined ones
+		def.validateFuncs = fn
+		return nil
+	}
+}
+
+// WithDefinition allows to use the client definition in order to create the container.
+// This option is useful when client code defines a definition and wants its values
+// to be updated on container creation.
+// If used, it's mandatory to pass this option as the last option to the container creation,
+// so that the client definition is updated with the SDK definition.
+func WithDefinition(def *Definition) CustomizeDefinitionOption {
+	return func(d *Definition) error {
+		// validate the definition
+		if d == nil {
+			return errors.New("definition is nil")
+		}
+
+		if def == nil {
+			return errors.New("client definition is nil")
+		}
+
+		// return the definition to the caller
+		*def = *d
 		return nil
 	}
 }

--- a/container/options.go
+++ b/container/options.go
@@ -277,7 +277,10 @@ func WithAdditionalWaitStrategyAndDeadline(deadline time.Duration, strategies ..
 	}
 }
 
-// WithAlwaysPull will pull the image before starting the container
+// WithAlwaysPull will pull the image before starting the container.
+// Do not use this option in case the image is the result of a build
+// and not yet pushed to a registry. It will try to pull the image
+// from the registry, and fail.
 func WithAlwaysPull() CustomizeDefinitionOption {
 	return func(def *Definition) error {
 		def.alwaysPullImage = true

--- a/container/options_test.go
+++ b/container/options_test.go
@@ -527,7 +527,7 @@ func TestWithValidateFuncs(t *testing.T) {
 
 		opt := WithValidateFuncs()
 		require.ErrorContains(t, opt.Customize(&def), "validate function is nil")
-		require.Len(t, def.validateFuncs, 0)
+		require.Empty(t, def.validateFuncs)
 	})
 
 	t.Run("add-nil", func(t *testing.T) {
@@ -535,7 +535,7 @@ func TestWithValidateFuncs(t *testing.T) {
 
 		opt := WithValidateFuncs(nil)
 		require.ErrorContains(t, opt.Customize(&def), "validate function is nil")
-		require.Len(t, def.validateFuncs, 0)
+		require.Empty(t, def.validateFuncs)
 	})
 
 	t.Run("add-one-nil", func(t *testing.T) {
@@ -545,7 +545,7 @@ func TestWithValidateFuncs(t *testing.T) {
 			return nil
 		}, nil)
 		require.ErrorContains(t, opt.Customize(&def), "validate function is nil")
-		require.Len(t, def.validateFuncs, 0)
+		require.Empty(t, def.validateFuncs)
 	})
 
 	t.Run("add-single", func(t *testing.T) {

--- a/container/options_test.go
+++ b/container/options_test.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 	"time"
 
@@ -518,4 +519,72 @@ func TestWithWaitStrategy(t *testing.T) {
 			)
 		})
 	})
+}
+
+func TestWithValidateFuncs(t *testing.T) {
+	t.Run("add-zero", func(t *testing.T) {
+		def := Definition{}
+
+		opt := WithValidateFuncs()
+		require.ErrorContains(t, opt.Customize(&def), "validate function is nil")
+		require.Len(t, def.validateFuncs, 0)
+	})
+
+	t.Run("add-nil", func(t *testing.T) {
+		def := Definition{}
+
+		opt := WithValidateFuncs(nil)
+		require.ErrorContains(t, opt.Customize(&def), "validate function is nil")
+		require.Len(t, def.validateFuncs, 0)
+	})
+
+	t.Run("add-one-nil", func(t *testing.T) {
+		def := Definition{}
+
+		opt := WithValidateFuncs(func() error {
+			return nil
+		}, nil)
+		require.ErrorContains(t, opt.Customize(&def), "validate function is nil")
+		require.Len(t, def.validateFuncs, 0)
+	})
+
+	t.Run("add-single", func(t *testing.T) {
+		def := Definition{}
+
+		opt := WithValidateFuncs(func() error {
+			return errors.New("test error")
+		})
+		require.NoError(t, opt.Customize(&def))
+		require.Len(t, def.validateFuncs, 1)
+	})
+
+	t.Run("add-multiple", func(t *testing.T) {
+		def := Definition{}
+
+		opt := WithValidateFuncs(
+			func() error {
+				return errors.New("test error")
+			},
+			func() error {
+				return errors.New("test error 2")
+			},
+		)
+		require.NoError(t, opt.Customize(&def))
+		require.Len(t, def.validateFuncs, 2)
+	})
+}
+
+func TestWithDefinition(t *testing.T) {
+	def1 := Definition{
+		image: "alpine",
+	}
+
+	def2 := Definition{
+		image: "busybox",
+	}
+
+	opt := WithDefinition(&def2)
+	require.NoError(t, opt.Customize(&def1))
+	require.Equal(t, "alpine", def1.image)
+	require.Equal(t, "alpine", def2.image)
 }

--- a/image/pull.go
+++ b/image/pull.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/go-sdk/client"
 	"github.com/docker/go-sdk/config"
-	"github.com/docker/go-sdk/config/auth"
 )
 
 // defaultPullHandler is the default pull handler function.
@@ -63,25 +62,23 @@ func Pull(ctx context.Context, imageName string, opts ...PullOption) error {
 	if err != nil {
 		pullOpts.pullClient.Logger().Warn("failed to get image auth, setting empty credentials for the image", "image", imageName, "error", err)
 	} else {
-		ref, err := auth.ParseImageRef(imageName)
-		if err != nil {
-			return fmt.Errorf("parse image ref: %w", err)
+		// there must be only one auth config for the image
+		var tmp config.AuthConfig
+		for _, ac := range authConfigs {
+			tmp = ac
 		}
 
-		creds, ok := authConfigs[ref.Registry]
-		if !ok {
-			pullOpts.pullClient.Logger().Warn("no image auth found for image, setting empty credentials for the image. This is expected for public images", "image", imageName)
-		}
-
-		authConfig := config.AuthConfig{
-			Username: creds.Username,
-			Password: creds.Password,
-		}
-		encodedJSON, err := json.Marshal(authConfig)
-		if err != nil {
-			pullOpts.pullClient.Logger().Warn("failed to marshal image auth, setting empty credentials for the image", "image", imageName, "error", err)
-		} else {
-			pullOpts.pullOptions.RegistryAuth = base64.URLEncoding.EncodeToString(encodedJSON)
+		if tmp.Username != "" && tmp.Password != "" {
+			authConfig := config.AuthConfig{
+				Username: tmp.Username,
+				Password: tmp.Password,
+			}
+			encodedJSON, err := json.Marshal(authConfig)
+			if err != nil {
+				pullOpts.pullClient.Logger().Warn("failed to marshal image auth, setting empty credentials for the image", "image", imageName, "error", err)
+			} else {
+				pullOpts.pullOptions.RegistryAuth = base64.URLEncoding.EncodeToString(encodedJSON)
+			}
 		}
 	}
 

--- a/image/pull.go
+++ b/image/pull.go
@@ -63,6 +63,10 @@ func Pull(ctx context.Context, imageName string, opts ...PullOption) error {
 		pullOpts.pullClient.Logger().Warn("failed to get image auth, setting empty credentials for the image", "image", imageName, "error", err)
 	} else {
 		// there must be only one auth config for the image
+		if len(authConfigs) > 1 {
+			return fmt.Errorf("multiple auth configs found for image %s, expected only one", imageName)
+		}
+
 		var tmp config.AuthConfig
 		for _, ac := range authConfigs {
 			tmp = ac

--- a/image/pull.go
+++ b/image/pull.go
@@ -72,17 +72,15 @@ func Pull(ctx context.Context, imageName string, opts ...PullOption) error {
 			tmp = ac
 		}
 
-		if tmp.Username != "" && tmp.Password != "" {
-			authConfig := config.AuthConfig{
-				Username: tmp.Username,
-				Password: tmp.Password,
-			}
-			encodedJSON, err := json.Marshal(authConfig)
-			if err != nil {
-				pullOpts.pullClient.Logger().Warn("failed to marshal image auth, setting empty credentials for the image", "image", imageName, "error", err)
-			} else {
-				pullOpts.pullOptions.RegistryAuth = base64.URLEncoding.EncodeToString(encodedJSON)
-			}
+		authConfig := config.AuthConfig{
+			Username: tmp.Username,
+			Password: tmp.Password,
+		}
+		encodedJSON, err := json.Marshal(authConfig)
+		if err != nil {
+			pullOpts.pullClient.Logger().Warn("failed to marshal image auth, setting empty credentials for the image", "image", imageName, "error", err)
+		} else {
+			pullOpts.pullOptions.RegistryAuth = base64.URLEncoding.EncodeToString(encodedJSON)
 		}
 	}
 

--- a/volume/volume_test.go
+++ b/volume/volume_test.go
@@ -26,7 +26,7 @@ func TestNew(t *testing.T) {
 		require.NotEmpty(t, v.Name) // Docker generated a random name for the volume.
 		require.Equal(t, "true", labels["com.docker.sdk"])
 		require.Equal(t, "go", labels["com.docker.sdk.lang"])
-		require.Equal(t, client.Version(), labels["com.docker.sdk.version"])
+		require.Equal(t, client.Version(), labels["com.docker.sdk.client"])
 		require.NotEmpty(t, v.Mountpoint)
 	})
 
@@ -41,7 +41,7 @@ func TestNew(t *testing.T) {
 		require.NotEmpty(t, v.Name) // Docker generated a random name for the volume.
 		require.Equal(t, "true", labels["com.docker.sdk"])
 		require.Equal(t, "go", labels["com.docker.sdk.lang"])
-		require.Equal(t, client.Version(), labels["com.docker.sdk.version"])
+		require.Equal(t, client.Version(), labels["com.docker.sdk.client"])
 	})
 
 	t.Run("with-name", func(t *testing.T) {
@@ -55,7 +55,7 @@ func TestNew(t *testing.T) {
 		labels := v.Labels
 		require.Equal(t, "true", labels["com.docker.sdk"])
 		require.Equal(t, "go", labels["com.docker.sdk.lang"])
-		require.Equal(t, client.Version(), labels["com.docker.sdk.version"])
+		require.Equal(t, client.Version(), labels["com.docker.sdk.client"])
 	})
 
 	t.Run("with-very-long-name", func(t *testing.T) {


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR makes the lifecyclehooks a bit more configurable:

- adds custom validator funcs to be used by client code to validate the state of the internal container definition. The library adds a default set of validators: image is present, and mounts
- simpifies the extraction of image credentials, avoiding double parsing of the image reference: the call to `config.AuthConfigs(imageName)` just have the auth configs, indexed by registry, so only one element will be present in the map.
- calculates the image substitution after the creating hook, which could have been used for building an image, and therefore, generating a different image tag.
- adds Definition accessors for the image substitutors, and labels, as client code could use it for processing the pre-creation.
- changes the docker label added by the client module: instead of `com.docker.sdk.version` it uses `com.docker.sdk.client=1.0.0` which is more accurate and consistent with the rest of the modules contributing labels.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Support Testcontainers uses cases, in particular the build of images

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
