### PR TITLE
fix(auth): fix authentication for private images on DockerHub.

### DIFF
--- a/config/auth/registry.go
+++ b/config/auth/registry.go
@@ -52,11 +52,11 @@ func ParseImageRef(imageRef string) (ImageReference, error) {
 	return imgRef, nil
 }
 
-// resolveRegistryHost can be used to transform a docker registry host name into what is used for the docker config/cred helpers
+// ResolveRegistryHost can be used to transform a docker registry host name into what is used for the docker config/cred helpers
 //
 // This is useful for using with containerd authorizers.
 // Naturally this only transforms docker hub URLs.
-func resolveRegistryHost(host string) string {
+func ResolveRegistryHost(host string) string {
 	switch host {
 	case "index.docker.io", "docker.io", IndexDockerIO, "registry-1.docker.io":
 		return IndexDockerIO

--- a/config/auth/registry_unit_test.go
+++ b/config/auth/registry_unit_test.go
@@ -7,12 +7,12 @@ import (
 )
 
 func TestResolveRegistryHost(t *testing.T) {
-	require.Equal(t, IndexDockerIO, resolveRegistryHost("index.docker.io"))
-	require.Equal(t, IndexDockerIO, resolveRegistryHost("docker.io"))
-	require.Equal(t, IndexDockerIO, resolveRegistryHost("registry-1.docker.io"))
-	require.Equal(t, "foobar.com", resolveRegistryHost("foobar.com"))
-	require.Equal(t, "http://foobar.com", resolveRegistryHost("http://foobar.com"))
-	require.Equal(t, "https://foobar.com", resolveRegistryHost("https://foobar.com"))
-	require.Equal(t, "http://foobar.com:8080", resolveRegistryHost("http://foobar.com:8080"))
-	require.Equal(t, "https://foobar.com:8080", resolveRegistryHost("https://foobar.com:8080"))
+	require.Equal(t, IndexDockerIO, ResolveRegistryHost("index.docker.io"))
+	require.Equal(t, IndexDockerIO, ResolveRegistryHost("docker.io"))
+	require.Equal(t, IndexDockerIO, ResolveRegistryHost("registry-1.docker.io"))
+	require.Equal(t, "foobar.com", ResolveRegistryHost("foobar.com"))
+	require.Equal(t, "http://foobar.com", ResolveRegistryHost("http://foobar.com"))
+	require.Equal(t, "https://foobar.com", ResolveRegistryHost("https://foobar.com"))
+	require.Equal(t, "http://foobar.com:8080", ResolveRegistryHost("http://foobar.com:8080"))
+	require.Equal(t, "https://foobar.com:8080", ResolveRegistryHost("https://foobar.com:8080"))
 }

--- a/config/config.go
+++ b/config/config.go
@@ -207,6 +207,9 @@ func (c *Config) Save() error {
 
 // resolveAuthConfigForHostname performs the actual auth config resolution
 func (c *Config) resolveAuthConfigForHostname(hostname string) (AuthConfig, error) {
+	// Normalize Docker registry hostnames
+	hostname = auth.ResolveRegistryHost(hostname)
+
 	// Check credential helpers first
 	if helper, exists := c.CredentialHelpers[hostname]; exists {
 		return c.resolveFromCredentialHelper(helper, hostname)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

Fixes a bug where go-sdk was not properly resolving authentication for DockerHub. For example, pulling a private image from DockerHub would result in `Error response from daemon: pull access denied for <image-name>, repository does not exist or may require 'docker login` even though the user is logged in and Docker CLI is able to pull the image.

The bug is in function `config.resolveAuthConfigForHostname()`, where it was failing to convert/normalize the registry portion of a DockerHub image (e.g., `docker.io`) into something that would match the way the registry is referred to in the authentication config (i.e., `https://index.docker.io/v1). The code already has a function called `auth.ResolveRegistryHost` to do this conversion, but that function was not being called from anywhere. Fix it by calling that function in `config.resolveAuthConfigForHostname()`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Without this fix, go-sdk can't be used to pull non-public images from DockerHub.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

I tested it manually using a private image in DockerHub and checking that go-sdk is now able to pull the image without problem, confirming that it's able to get the authentication info for DockerHub from `~/.docker/config.json`. Additionally I tested with a private image on GitHub container registry, and go-sdk was able to pull it without problem too (this last scenario was not broken to start with, just sanity checking).

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
