### PR TITLE
fix(client): add client.ContainerExecStart().

### DIFF
--- a/client/client.container.go
+++ b/client/client.container.go
@@ -27,7 +27,10 @@ func (c *Client) ContainerCreate(ctx context.Context, config *container.Config, 
 	return dockerClient.ContainerCreate(ctx, config, hostConfig, networkingConfig, platform, name)
 }
 
-// ContainerExecStart starts a new exec instance.
+// ContainerExecAttach attaches a connection to an exec process in the server.
+// It returns a types.HijackedConnection with the hijacked connection
+// and the a reader to get output. It's up to the called to close
+// the hijacked connection by calling types.HijackedResponse.Close.
 func (c *Client) ContainerExecAttach(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error) {
 	dockerClient, err := c.Client()
 	if err != nil {
@@ -45,6 +48,16 @@ func (c *Client) ContainerExecCreate(ctx context.Context, containerID string, op
 	}
 
 	return dockerClient.ContainerExecCreate(ctx, containerID, options)
+}
+
+// ContainerExecStart starts an exec instance.
+func (c *Client) ContainerExecStart(ctx context.Context, execID string, config container.ExecStartOptions) error {
+	dockerClient, err := c.Client()
+	if err != nil {
+		return fmt.Errorf("docker client: %w", err)
+	}
+
+	return dockerClient.ContainerExecStart(ctx, execID, config)
 }
 
 // ContainerExecInspect inspects a exec instance.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

The client type is missing the `ContainerExecStart()` method that calls the corresponding function in the Docker client. This commit adds this missing method.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Adding `ContainerExecStart` is important for parity between the go-sdk Client type methods and the corresponding lower-level Docker client.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
