### PR TITLE
chore(config): use registry.AuthConfig everywhere possible and deprecated config.AuthConfig

### DIFF
--- a/config/auth.go
+++ b/config/auth.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 
 	"github.com/docker/docker/api/types/registry"
@@ -16,7 +14,7 @@ const tokenUsername = "<token>"
 // AuthConfigs returns the auth configs for the given images.
 // The images slice must contain images that are used in a Dockerfile.
 // The returned map is keyed by the registry registry hostname for each image.
-func AuthConfigs(images ...string) (map[string]AuthConfig, error) {
+func AuthConfigs(images ...string) (map[string]registry.AuthConfig, error) {
 	cfg, err := Load()
 	if err != nil {
 		return nil, fmt.Errorf("load config: %w", err)
@@ -29,31 +27,16 @@ func AuthConfigs(images ...string) (map[string]AuthConfig, error) {
 //
 // This will use [Load] to read registry auth details from the config.
 // If the config doesn't exist, it will attempt to load registry credentials using the default credential helper for the platform.
-func AuthConfigForHostname(hostname string) (AuthConfig, error) {
+func AuthConfigForHostname(hostname string) (registry.AuthConfig, error) {
 	cfg, err := Load()
 	if err != nil {
-		return AuthConfig{}, fmt.Errorf("load config: %w", err)
+		return registry.AuthConfig{}, fmt.Errorf("load config: %w", err)
 	}
 
 	return cfg.AuthConfigForHostname(hostname)
 }
 
-func (authConfig AuthConfig) EncodeBase64() (string, error) {
-	jsonAuth, err := json.Marshal(authConfig)
-	if err != nil {
-		return "", err
-	}
-	return base64.URLEncoding.EncodeToString(jsonAuth), nil
-}
-
-func (authConfig AuthConfig) ToRegistryAuthConfig() registry.AuthConfig {
-	return registry.AuthConfig{
-		Username:      authConfig.Username,
-		Password:      authConfig.Password,
-		Auth:          authConfig.Auth,
-		Email:         "",
-		ServerAddress: authConfig.ServerAddress,
-		IdentityToken: authConfig.IdentityToken,
-		RegistryToken: authConfig.RegistryToken,
-	}
+// EncodeBase64 encodes an AuthConfig into base64.
+func EncodeBase64(authConfig registry.AuthConfig) (string, error) {
+	return registry.EncodeAuthConfig(authConfig)
 }

--- a/config/config_benchmarks_test.go
+++ b/config/config_benchmarks_test.go
@@ -4,11 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker/api/types/registry"
 )
 
 func BenchmarkAuthConfigCaching(b *testing.B) {
 	cfg := Config{
-		AuthConfigs: map[string]AuthConfig{
+		AuthConfigs: map[string]registry.AuthConfig{
 			"test.io": {Username: "user", Password: "pass"},
 		},
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,11 +7,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker/api/types/registry"
 )
 
 func TestConfig_AuthConfigsForImages(t *testing.T) {
 	config := Config{
-		AuthConfigs: map[string]AuthConfig{
+		AuthConfigs: map[string]registry.AuthConfig{
 			"registry1.io": {Username: "user1", Password: "pass1"},
 			"registry2.io": {Username: "user2", Password: "pass2"},
 		},
@@ -35,7 +37,7 @@ func TestConfig_AuthConfigsForImages(t *testing.T) {
 
 func TestConfig_CacheManagement(t *testing.T) {
 	config := Config{
-		AuthConfigs: map[string]AuthConfig{
+		AuthConfigs: map[string]registry.AuthConfig{
 			"test.io": {Username: "user", Password: "pass"},
 		},
 	}
@@ -63,7 +65,7 @@ func TestConfig_CacheManagement(t *testing.T) {
 
 func TestConfig_ConcurrentAccess(t *testing.T) {
 	config := Config{
-		AuthConfigs: map[string]AuthConfig{
+		AuthConfigs: map[string]registry.AuthConfig{
 			"test.io": {Username: "user", Password: "pass"},
 		},
 	}
@@ -87,13 +89,13 @@ func TestConfig_ConcurrentAccess(t *testing.T) {
 
 func TestConfig_CacheKeyGeneration(t *testing.T) {
 	config1 := Config{
-		AuthConfigs: map[string]AuthConfig{
+		AuthConfigs: map[string]registry.AuthConfig{
 			"test.io": {Username: "user1", Password: "pass1"},
 		},
 	}
 
 	config2 := Config{
-		AuthConfigs: map[string]AuthConfig{
+		AuthConfigs: map[string]registry.AuthConfig{
 			"test.io": {Username: "user2", Password: "pass2"},
 		},
 	}
@@ -119,7 +121,7 @@ func TestConfigSave(t *testing.T) {
 	c := Config{
 		filepath:       filepath.Join(dockerDir, FileName),
 		CurrentContext: "test",
-		AuthConfigs:    map[string]AuthConfig{},
+		AuthConfigs:    map[string]registry.AuthConfig{},
 	}
 
 	require.NoError(t, c.Save())

--- a/config/credentials_helpers.go
+++ b/config/credentials_helpers.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+
+	"github.com/docker/docker/api/types/registry"
 )
 
 // Errors from credential helpers.
@@ -34,8 +36,8 @@ var (
 // Hostnames should already be resolved using [ResolveRegistryHost]
 //
 // If the username string is empty, the password string is an identity token.
-func credentialsFromHelper(helper, hostname string) (AuthConfig, error) {
-	var creds AuthConfig
+func credentialsFromHelper(helper, hostname string) (registry.AuthConfig, error) {
+	var creds registry.AuthConfig
 	credHelperName := helper
 	if helper == "" {
 		helper, helperErr := getCredentialHelper()

--- a/config/types.go
+++ b/config/types.go
@@ -1,6 +1,10 @@
 package config
 
-import "sync/atomic"
+import (
+	"sync/atomic"
+
+	"github.com/docker/docker/api/types/registry"
+)
 
 const (
 	// EnvOverrideDir is the name of the environment variable that can be
@@ -19,33 +23,33 @@ const (
 
 // Config represents the on disk format of the docker CLI's config file.
 type Config struct {
-	filepath             string                 `json:"-"`
-	AuthConfigs          map[string]AuthConfig  `json:"auths"`
-	HTTPHeaders          map[string]string      `json:"HttpHeaders,omitempty"`
-	PsFormat             string                 `json:"psFormat,omitempty"`
-	ImagesFormat         string                 `json:"imagesFormat,omitempty"`
-	NetworksFormat       string                 `json:"networksFormat,omitempty"`
-	PluginsFormat        string                 `json:"pluginsFormat,omitempty"`
-	VolumesFormat        string                 `json:"volumesFormat,omitempty"`
-	StatsFormat          string                 `json:"statsFormat,omitempty"`
-	DetachKeys           string                 `json:"detachKeys,omitempty"`
-	CredentialsStore     string                 `json:"credsStore,omitempty"`
-	CredentialHelpers    map[string]string      `json:"credHelpers,omitempty"`
-	Filename             string                 `json:"-"` // Note: for internal use only.
-	ServiceInspectFormat string                 `json:"serviceInspectFormat,omitempty"`
-	ServicesFormat       string                 `json:"servicesFormat,omitempty"`
-	TasksFormat          string                 `json:"tasksFormat,omitempty"`
-	SecretFormat         string                 `json:"secretFormat,omitempty"`
-	ConfigFormat         string                 `json:"configFormat,omitempty"`
-	NodesFormat          string                 `json:"nodesFormat,omitempty"`
-	PruneFilters         []string               `json:"pruneFilters,omitempty"`
-	Proxies              map[string]ProxyConfig `json:"proxies,omitempty"`
-	Experimental         string                 `json:"experimental,omitempty"`
-	StackOrchestrator    string                 `json:"stackOrchestrator,omitempty"`
-	Kubernetes           *KubernetesConfig      `json:"kubernetes,omitempty"`
-	CurrentContext       string                 `json:"currentContext,omitempty"`
-	CLIPluginsExtraDirs  []string               `json:"cliPluginsExtraDirs,omitempty"`
-	Aliases              map[string]string      `json:"aliases,omitempty"`
+	filepath             string                         `json:"-"`
+	AuthConfigs          map[string]registry.AuthConfig `json:"auths"`
+	HTTPHeaders          map[string]string              `json:"HttpHeaders,omitempty"`
+	PsFormat             string                         `json:"psFormat,omitempty"`
+	ImagesFormat         string                         `json:"imagesFormat,omitempty"`
+	NetworksFormat       string                         `json:"networksFormat,omitempty"`
+	PluginsFormat        string                         `json:"pluginsFormat,omitempty"`
+	VolumesFormat        string                         `json:"volumesFormat,omitempty"`
+	StatsFormat          string                         `json:"statsFormat,omitempty"`
+	DetachKeys           string                         `json:"detachKeys,omitempty"`
+	CredentialsStore     string                         `json:"credsStore,omitempty"`
+	CredentialHelpers    map[string]string              `json:"credHelpers,omitempty"`
+	Filename             string                         `json:"-"` // Note: for internal use only.
+	ServiceInspectFormat string                         `json:"serviceInspectFormat,omitempty"`
+	ServicesFormat       string                         `json:"servicesFormat,omitempty"`
+	TasksFormat          string                         `json:"tasksFormat,omitempty"`
+	SecretFormat         string                         `json:"secretFormat,omitempty"`
+	ConfigFormat         string                         `json:"configFormat,omitempty"`
+	NodesFormat          string                         `json:"nodesFormat,omitempty"`
+	PruneFilters         []string                       `json:"pruneFilters,omitempty"`
+	Proxies              map[string]ProxyConfig         `json:"proxies,omitempty"`
+	Experimental         string                         `json:"experimental,omitempty"`
+	StackOrchestrator    string                         `json:"stackOrchestrator,omitempty"`
+	Kubernetes           *KubernetesConfig              `json:"kubernetes,omitempty"`
+	CurrentContext       string                         `json:"currentContext,omitempty"`
+	CLIPluginsExtraDirs  []string                       `json:"cliPluginsExtraDirs,omitempty"`
+	Aliases              map[string]string              `json:"aliases,omitempty"`
 
 	// Cache pointer (unexported, not included in JSON, safe to copy)
 	cache atomic.Value // stores *authConfigCache
@@ -61,19 +65,8 @@ type ProxyConfig struct {
 }
 
 // AuthConfig contains authorization information for connecting to a Registry.
-type AuthConfig struct {
-	Username      string `json:"username,omitempty"`
-	Password      string `json:"password,omitempty"`
-	Auth          string `json:"auth,omitempty"`
-	ServerAddress string `json:"serveraddress,omitempty"`
-
-	// IdentityToken is used to authenticate the user and get
-	// an access token for the registry.
-	IdentityToken string `json:"identitytoken,omitempty"`
-
-	// RegistryToken is a bearer token to be sent to a registry.
-	RegistryToken string `json:"registrytoken,omitempty"`
-}
+// Deprecated: prefer use of registry.AuthConfig
+type AuthConfig registry.AuthConfig
 
 // KubernetesConfig contains Kubernetes orchestrator settings.
 type KubernetesConfig struct {

--- a/legacyadapters/README.md
+++ b/legacyadapters/README.md
@@ -23,11 +23,12 @@ Convert SDK auth config to Docker Engine API format:
 
 ```go
 import (
+    "github.com/docker/docker/api/types/registry"
     "github.com/docker/go-sdk/config"
     legacyconfig "github.com/docker/go-sdk/legacyadapters/config"
 )
 
-sdkAuth := config.AuthConfig{
+sdkAuth := registry.AuthConfig{
     Username:      "myuser",
     Password:      "mypass",
     ServerAddress: "registry.example.com",
@@ -46,7 +47,7 @@ Convert SDK config to Docker CLI config file format:
 
 ```go
 sdkConfig := config.Config{
-    AuthConfigs: map[string]config.AuthConfig{
+    AuthConfigs: map[string]registry.AuthConfig{
         "registry.example.com": {
             Username: "user",
             Password: "pass",

--- a/legacyadapters/config/auth.go
+++ b/legacyadapters/config/auth.go
@@ -14,19 +14,12 @@ import (
 )
 
 // ToRegistryAuthConfig converts a go-sdk AuthConfig to Docker Engine API registry.AuthConfig.
+// Since AuthConfig is now an alias to registry.AuthConfig, this simply returns the input.
 //
 // Deprecated: This function is deprecated and will be removed in a future release.
 // Use the native go-sdk types directly and these adapters only when needed.
-func ToRegistryAuthConfig(authConfig config.AuthConfig) registry.AuthConfig {
-	return registry.AuthConfig{
-		Username:      authConfig.Username,
-		Password:      authConfig.Password,
-		Auth:          authConfig.Auth,
-		Email:         "",
-		ServerAddress: authConfig.ServerAddress,
-		IdentityToken: authConfig.IdentityToken,
-		RegistryToken: authConfig.RegistryToken,
-	}
+func ToRegistryAuthConfig(authConfig registry.AuthConfig) registry.AuthConfig {
+	return authConfig
 }
 
 // ToConfigFile converts a go-sdk Config to Docker CLI configfile.ConfigFile.
@@ -69,7 +62,7 @@ func ToConfigFile(cfg config.Config) *configfile.ConfigFile {
 //
 // Deprecated: This function is deprecated and will be removed in a future release.
 // Use the native go-sdk types directly and these adapters only when needed.
-func ToCLIAuthConfig(authConfig config.AuthConfig) types.AuthConfig {
+func ToCLIAuthConfig(authConfig registry.AuthConfig) types.AuthConfig {
 	return types.AuthConfig{
 		Username:      authConfig.Username,
 		Password:      authConfig.Password,
@@ -85,7 +78,7 @@ func ToCLIAuthConfig(authConfig config.AuthConfig) types.AuthConfig {
 //
 // Deprecated: This function is deprecated and will be removed in a future release.
 // Use the native go-sdk types directly and these adapters only when needed.
-func ToCLIAuthConfigs(authConfigs map[string]config.AuthConfig) map[string]types.AuthConfig {
+func ToCLIAuthConfigs(authConfigs map[string]registry.AuthConfig) map[string]types.AuthConfig {
 	result := make(map[string]types.AuthConfig, len(authConfigs))
 	for name, authConfig := range authConfigs {
 		result[name] = ToCLIAuthConfig(authConfig)

--- a/legacyadapters/config/auth_test.go
+++ b/legacyadapters/config/auth_test.go
@@ -14,19 +14,19 @@ import (
 func TestToRegistryAuthConfig(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    config.AuthConfig
+		input    registry.AuthConfig
 		expected registry.AuthConfig
 	}{
 		{
 			name:  "empty config",
-			input: config.AuthConfig{},
+			input: registry.AuthConfig{},
 			expected: registry.AuthConfig{
 				Email: "",
 			},
 		},
 		{
 			name: "basic username and password",
-			input: config.AuthConfig{
+			input: registry.AuthConfig{
 				Username: "testuser",
 				Password: "testpass",
 			},
@@ -38,7 +38,7 @@ func TestToRegistryAuthConfig(t *testing.T) {
 		},
 		{
 			name: "with auth field",
-			input: config.AuthConfig{
+			input: registry.AuthConfig{
 				Username: "user",
 				Password: "pass",
 				Auth:     "dXNlcjpwYXNz", // base64 encoded "user:pass"
@@ -52,7 +52,7 @@ func TestToRegistryAuthConfig(t *testing.T) {
 		},
 		{
 			name: "with server address",
-			input: config.AuthConfig{
+			input: registry.AuthConfig{
 				Username:      "user",
 				Password:      "pass",
 				ServerAddress: "registry.example.com",
@@ -66,7 +66,7 @@ func TestToRegistryAuthConfig(t *testing.T) {
 		},
 		{
 			name: "with identity token",
-			input: config.AuthConfig{
+			input: registry.AuthConfig{
 				Username:      "user",
 				IdentityToken: "identity-token-123",
 			},
@@ -78,7 +78,7 @@ func TestToRegistryAuthConfig(t *testing.T) {
 		},
 		{
 			name: "with registry token",
-			input: config.AuthConfig{
+			input: registry.AuthConfig{
 				Username:      "user",
 				RegistryToken: "registry-token-456",
 			},
@@ -90,7 +90,7 @@ func TestToRegistryAuthConfig(t *testing.T) {
 		},
 		{
 			name: "complete config",
-			input: config.AuthConfig{
+			input: registry.AuthConfig{
 				Username:      "testuser",
 				Password:      "testpass",
 				Auth:          "dGVzdHVzZXI6dGVzdHBhc3M=", // base64 encoded "testuser:testpass"
@@ -120,7 +120,7 @@ func TestToRegistryAuthConfig(t *testing.T) {
 
 func TestToRegistryAuthConfig_EmailAlwaysEmpty(t *testing.T) {
 	// Test that Email field is always set to empty string, regardless of input
-	input := config.AuthConfig{
+	input := registry.AuthConfig{
 		Username: "user",
 		Password: "pass",
 	}
@@ -153,7 +153,7 @@ func TestConfigToConfigFile(t *testing.T) {
 		{
 			name: "basic config with auth",
 			input: config.Config{
-				AuthConfigs: map[string]config.AuthConfig{
+				AuthConfigs: map[string]registry.AuthConfig{
 					"registry.example.com": {
 						Username: "testuser",
 						Password: "testpass",
@@ -217,19 +217,19 @@ func TestToCLIAuthConfig(t *testing.T) {
 	t.Helper()
 	tests := []struct {
 		name     string
-		input    config.AuthConfig
+		input    registry.AuthConfig
 		expected types.AuthConfig
 	}{
 		{
 			name:  "empty config",
-			input: config.AuthConfig{},
+			input: registry.AuthConfig{},
 			expected: types.AuthConfig{
 				Email: "",
 			},
 		},
 		{
 			name: "basic username and password",
-			input: config.AuthConfig{
+			input: registry.AuthConfig{
 				Username: "testuser",
 				Password: "testpass",
 			},
@@ -241,7 +241,7 @@ func TestToCLIAuthConfig(t *testing.T) {
 		},
 		{
 			name: "with auth field",
-			input: config.AuthConfig{
+			input: registry.AuthConfig{
 				Username: "user",
 				Password: "pass",
 				Auth:     "dXNlcjpwYXNz",
@@ -255,7 +255,7 @@ func TestToCLIAuthConfig(t *testing.T) {
 		},
 		{
 			name: "with server address and identity token",
-			input: config.AuthConfig{
+			input: registry.AuthConfig{
 				Username:      "user",
 				ServerAddress: "registry.example.com",
 				IdentityToken: "identity-token-123",
@@ -269,7 +269,7 @@ func TestToCLIAuthConfig(t *testing.T) {
 		},
 		{
 			name: "with registry token included",
-			input: config.AuthConfig{
+			input: registry.AuthConfig{
 				Username:      "user",
 				Password:      "pass",
 				RegistryToken: "registry-token-456",
@@ -295,17 +295,17 @@ func TestToCLIAuthConfigs(t *testing.T) {
 	t.Helper()
 	tests := []struct {
 		name     string
-		input    map[string]config.AuthConfig
+		input    map[string]registry.AuthConfig
 		expected map[string]types.AuthConfig
 	}{
 		{
 			name:     "empty map",
-			input:    map[string]config.AuthConfig{},
+			input:    map[string]registry.AuthConfig{},
 			expected: map[string]types.AuthConfig{},
 		},
 		{
 			name: "single auth config",
-			input: map[string]config.AuthConfig{
+			input: map[string]registry.AuthConfig{
 				"registry.example.com": {
 					Username: "testuser",
 					Password: "testpass",
@@ -321,7 +321,7 @@ func TestToCLIAuthConfigs(t *testing.T) {
 		},
 		{
 			name: "multiple auth configs",
-			input: map[string]config.AuthConfig{
+			input: map[string]registry.AuthConfig{
 				"registry1.example.com": {
 					Username: "user1",
 					Password: "pass1",


### PR DESCRIPTION
## What does this PR do?

use registry.AuthConfig everywhere possible and deprecated config.AuthConfig

## Why is it important?

this reduce coupling with `config` module, relying on existing docker API types (strictly equivalent)