### PR TITLE
fix(container): proper error message on empty container names

### DIFF
--- a/container/options.go
+++ b/container/options.go
@@ -21,7 +21,7 @@ import (
 	"github.com/docker/go-sdk/network"
 )
 
-var ErrReuseEmptyName = errors.New("with reuse option a container name mustn't be empty")
+var ErrContainerNameEmpty = errors.New("container name mustn't be empty")
 
 // ContainerCustomizer is an interface that can be used to configure the container
 // definition. The passed definition is merged with the default one.
@@ -181,10 +181,11 @@ func WithAdditionalHostConfigModifier(modifier func(hostConfig *container.HostCo
 }
 
 // WithName will set the name of the container.
+// It returns an error if the container name is empty.
 func WithName(containerName string) CustomizeDefinitionOption {
 	return func(def *Definition) error {
 		if containerName == "" {
-			return ErrReuseEmptyName
+			return ErrContainerNameEmpty
 		}
 		def.name = containerName
 		return nil

--- a/container/options_test.go
+++ b/container/options_test.go
@@ -496,7 +496,7 @@ func TestWithName(t *testing.T) {
 		def := Definition{}
 
 		opt := WithName("")
-		require.ErrorIs(t, opt.Customize(&def), ErrReuseEmptyName)
+		require.ErrorIs(t, opt.Customize(&def), ErrContainerNameEmpty)
 	})
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It changes the `ErrReuseEmptyName` error to `ErrContainerNameEmpty`, updating the error message.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The reuse words were probably part of the fork of testcontainers-go

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
- See #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
