### PR TITLE
chore(release): add Go proxy refresh automation

### DIFF
--- a/.github/scripts/check-pre-release.sh
+++ b/.github/scripts/check-pre-release.sh
@@ -33,7 +33,7 @@ set -e
 
 # Source common functions
 readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-readonly ROOT_DIR="$( cd "${SCRIPT_DIR}/../.." && pwd )"
+source "${SCRIPT_DIR}/common.sh"
 
 # Get module name from argument and lowercase it
 readonly MODULE=$(echo "${1:-}" | tr '[:upper:]' '[:lower:]')
@@ -48,7 +48,7 @@ fi
 echo "Checking if pre-release was completed for module: ${MODULE}"
 
 # Check if next-tag file exists
-readonly BUILD_FILE="${ROOT_DIR}/.github/scripts/.build/${MODULE}-next-tag"
+readonly BUILD_FILE="${BUILD_DIR}/${MODULE}-next-tag"
 if [[ ! -f "${BUILD_FILE}" ]]; then
   echo "Error: Missing build file for module '${MODULE}' at ${BUILD_FILE}"
   echo "Please run 'make pre-release-all' or 'make pre-release' first (with DRY_RUN=false)"
@@ -66,8 +66,8 @@ if [[ ! -f "${VERSION_FILE}" ]]; then
   exit 1
 fi
 
-# Read current version from version.go (allow arbitrary whitespace around =)
-readonly CURRENT_VERSION=$(grep -o 'version[[:space:]]*=[[:space:]]*"[^"]*"' "${VERSION_FILE}" | cut -d'"' -f2)
+# Read current version from version.go
+readonly CURRENT_VERSION=$(get_version_from_file "${VERSION_FILE}")
 
 # Compare versions
 if [[ "${CURRENT_VERSION}" != "${NEXT_VERSION_NO_V}" ]]; then

--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -115,11 +115,20 @@ get_next_tag() {
   echo "${next_tag_path}"
 }
 
+# Extract version string from a version.go file
+# Usage: get_version_from_file <path_to_version.go>
+# Returns: version string (e.g., "0.1.0-alpha011")
+get_version_from_file() {
+  local file="$1"
+  # Use pattern that allows arbitrary whitespace around = sign
+  grep -o 'version[[:space:]]*=[[:space:]]*"[^"]*"' "$file" | cut -d'"' -f2
+}
+
 # Portable in-place sed editing that works on both BSD (macOS) and GNU (Linux) sed
 portable_sed() {
   local pattern="$1"
   local file="$2"
-  
+
   # Detect sed version and use appropriate syntax
   if sed --version >/dev/null 2>&1; then
     # GNU sed (Linux)

--- a/.github/scripts/refresh-proxy.sh
+++ b/.github/scripts/refresh-proxy.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# =============================================================================
+# Go Proxy Refresh Script
+# =============================================================================
+# Description: Triggers the Go proxy to refresh/fetch a module version
+#              This is useful to ensure pkg.go.dev has the latest version
+#
+# Usage: ./.github/scripts/refresh-proxy.sh <module>
+#
+# Arguments:
+#   module           - Name of the module to refresh (required)
+#                      Examples: client, container, config, context, image, network
+#
+# Examples:
+#   ./.github/scripts/refresh-proxy.sh client
+#   ./.github/scripts/refresh-proxy.sh container
+#
+# Dependencies:
+#   - git (for finding latest tag)
+#   - curl (for triggering Go proxy)
+#
+# =============================================================================
+
+set -e
+
+# Source common functions
+readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/common.sh"
+
+# Get module name from argument and lowercase it
+readonly MODULE=$(echo "${1:-}" | tr '[:upper:]' '[:lower:]')
+
+if [[ -z "$MODULE" ]]; then
+  echo "Error: Module name is required"
+  echo "Usage: $0 <module>"
+  echo "Example: $0 client"
+  exit 1
+fi
+
+echo "Refreshing Go proxy for module: ${MODULE}"
+
+# Check if version.go exists
+readonly VERSION_FILE="${ROOT_DIR}/${MODULE}/version.go"
+if [[ ! -f "${VERSION_FILE}" ]]; then
+  echo "Error: version.go not found at ${VERSION_FILE}"
+  exit 1
+fi
+
+# Read version from version.go
+VERSION=$(get_version_from_file "${VERSION_FILE}")
+
+if [[ -z "$VERSION" ]]; then
+  echo "Error: Could not extract version from ${VERSION_FILE}"
+  exit 1
+fi
+
+# Ensure version has v prefix for the tag
+if [[ ! "${VERSION}" =~ ^v ]]; then
+  VERSION="v${VERSION}"
+fi
+
+echo "Current version: ${VERSION}"
+echo "Triggering Go proxy refresh..."
+
+# Trigger Go proxy (bypass dry-run since this is a read-only operation)
+DRY_RUN=false curlGolangProxy "${MODULE}" "${VERSION}"
+
+echo "✅ Go proxy refresh completed for ${MODULE}@${VERSION}"
+echo "The module should be available at: https://pkg.go.dev/${GITHUB_REPO}/${MODULE}@${VERSION}"

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,8 @@ pre-release-all: clean-build-dir
 release-all:
 	$(call for-all-modules,make check-pre-release)
 	@./.github/scripts/release.sh
+
+# Refresh Go proxy for all modules
+refresh-proxy-all:
+	@echo "Refreshing Go proxy for all modules..."
+	$(call for-all-modules,make refresh-proxy)

--- a/commons-test.mk
+++ b/commons-test.mk
@@ -102,3 +102,11 @@ release:
 	fi
 	@echo "Finalizing release for module: $(MODULE_DIR)"
 	@$(ROOT_DIR)/.github/scripts/release.sh "$(MODULE_DIR)"
+
+.PHONY: refresh-proxy
+refresh-proxy:
+	@if [ -z "$(MODULE_DIR)" ]; then \
+		echo "Usage: make refresh-proxy, from one of the module directories (e.g. make refresh-proxy from client/ directory)"; \
+		exit 1; \
+	fi
+	@$(ROOT_DIR)/.github/scripts/refresh-proxy.sh "$(MODULE_DIR)"


### PR DESCRIPTION
## Summary
  - Add refresh-proxy.sh script to trigger pkg.go.dev to fetch newly released module versions
  - Add refresh-proxy and refresh-proxy-all Makefile targets for easy invocation
  - Refactor version extraction into shared get_version_from_file() function in common.sh
  - Update check-pre-release.sh to use common functions for better maintainability

  ## Test plan
  - [x] Verify make refresh-proxy works from individual module directories
  - [x] Verify make refresh-proxy-all refreshes all modules
  - [x] Confirm version extraction works correctly with various whitespace patterns

  🤖 Generated with [Claude Code](https://claude.com/claude-code)