### PR TITLE
docs(client): document non-nil Config requirement for ContainerCreate

### DIFF
--- a/client/client.container.go
+++ b/client/client.container.go
@@ -10,6 +10,9 @@ import (
 )
 
 // ContainerCreate creates a new container.
+//
+// Note: options.Config must not be nil. The SDK assumes a valid container
+// configuration and does not perform nil checks.
 func (c *sdkClient) ContainerCreate(ctx context.Context, options client.ContainerCreateOptions) (client.ContainerCreateResult, error) {
 	// Add the labels that identify this as a container created by the SDK.
 	AddSDKLabels(options.Config.Labels)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

Adds documentation to `ContainerCreate` in the Go SDK to clarify that `options.Config` **must not be nil**, as passing nil currently causes a panic.

## Why is it important?

This helps new users understand the expected invariant and prevents confusion when using `ContainerCreate`. It documents a real footgun without changing runtime behavior.

## Related issues

<!-- Optional: link an issue if there is one -->
- N/A

## How to test this PR

- Docs-only change, no runtime tests required.