### PR TITLE
fix(client): isolate ContainerList integration test

### DIFF
--- a/client/client.container_test.go
+++ b/client/client.container_test.go
@@ -40,7 +40,7 @@ func TestContainerList(t *testing.T) {
 
 	wg.Wait()
 
-	containers, err := dockerClient.ContainerList(context.Background(), dockerclient.ContainerListOptions{All: true, Filters: make(dockerclient.Filters).Add("label", "test=TestingContainer")})
+	containers, err := dockerClient.ContainerList(context.Background(), dockerclient.ContainerListOptions{All: true, Filters: make(dockerclient.Filters).Add("label", client.LabelBase+".integration-test=TestingContainer")})
 	require.NoError(t, err)
 	require.NotEmpty(t, containers.Items)
 	require.Len(t, containers.Items, max)
@@ -103,7 +103,7 @@ func createContainer(tb testing.TB, dockerClient client.SDKClient, img string, n
 			ExposedPorts: network.PortSet{
 				network.MustParsePort("80/tcp"): {},
 			},
-			Labels: map[string]string{"test": "TestingContainer"},
+			Labels: map[string]string{client.LabelBase + ".integration-test": "TestingContainer"},
 		},
 		Name: name,
 	})


### PR DESCRIPTION
## What does this PR do?

This PR fixes the `ContainerList` integration test by isolating it from the global Docker daemon state.  
The test now scopes its assertions to only the containers created during the test run, instead of relying on the total number of containers present on the system.

This makes the test deterministic and safe to run in environments where other containers may already exist (e.g. CI, developer machines).

## Why is it important?

The previous test behavior was environment-dependent and could fail if the Docker daemon already contained containers created outside the test.  
This change ensures the test is self-contained, reliable, and aligned with best practices for Docker integration tests.

## How to test this PR

1. Ensure Docker is running
2. Make sure there are existing containers on the system
3. Run the tests inside the `client` package:
   ```sh
   go test

