### PR TITLE
chore(release): bump module versions

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -10,7 +10,7 @@ replace (
 require (
 	github.com/caarlos0/env/v11 v11.3.1
 	github.com/containerd/errdefs v1.0.0
-	github.com/docker/go-sdk/context v0.1.0-alpha012
+	github.com/docker/go-sdk/context v0.1.0-alpha013
 	github.com/moby/moby/api v1.52.0
 	github.com/moby/moby/client v0.1.0
 	github.com/stretchr/testify v1.10.0
@@ -22,7 +22,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
-	github.com/docker/go-sdk/config v0.1.0-alpha012 // indirect
+	github.com/docker/go-sdk/config v0.1.0-alpha013 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/client/version.go
+++ b/client/version.go
@@ -1,7 +1,7 @@
 package client
 
 const (
-	version = "0.1.0-alpha012"
+	version = "0.1.0-alpha013"
 )
 
 // Version returns the version of the client package.

--- a/config/version.go
+++ b/config/version.go
@@ -1,7 +1,7 @@
 package config
 
 const (
-	version = "0.1.0-alpha012"
+	version = "0.1.0-alpha013"
 )
 
 // Version returns the version of the config package.

--- a/container/go.mod
+++ b/container/go.mod
@@ -15,10 +15,10 @@ require (
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/platforms v0.2.1
 	github.com/docker/go-connections v0.6.0
-	github.com/docker/go-sdk/client v0.1.0-alpha012
-	github.com/docker/go-sdk/config v0.1.0-alpha012
-	github.com/docker/go-sdk/image v0.1.0-alpha013
-	github.com/docker/go-sdk/network v0.1.0-alpha012
+	github.com/docker/go-sdk/client v0.1.0-alpha013
+	github.com/docker/go-sdk/config v0.1.0-alpha013
+	github.com/docker/go-sdk/image v0.1.0-alpha014
+	github.com/docker/go-sdk/network v0.1.0-alpha013
 	github.com/moby/moby/api v1.52.0
 	github.com/moby/moby/client v0.1.0
 	github.com/stretchr/testify v1.11.1
@@ -34,7 +34,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/docker/go-sdk/context v0.1.0-alpha012 // indirect
+	github.com/docker/go-sdk/context v0.1.0-alpha013 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/container/version.go
+++ b/container/version.go
@@ -3,7 +3,7 @@ package container
 import "github.com/docker/go-sdk/client"
 
 const (
-	version     = "0.1.0-alpha013"
+	version     = "0.1.0-alpha014"
 	moduleLabel = client.LabelBase + ".container"
 )
 

--- a/context/go.mod
+++ b/context/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/docker/go-sdk/config => ../config
 
 require (
-	github.com/docker/go-sdk/config v0.1.0-alpha012
+	github.com/docker/go-sdk/config v0.1.0-alpha013
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/stretchr/testify v1.10.0
 )

--- a/context/version.go
+++ b/context/version.go
@@ -1,7 +1,7 @@
 package context
 
 const (
-	version = "0.1.0-alpha012"
+	version = "0.1.0-alpha013"
 )
 
 // Version returns the version of the context package.

--- a/image/go.mod
+++ b/image/go.mod
@@ -11,8 +11,8 @@ replace (
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/containerd/errdefs v1.0.0
-	github.com/docker/go-sdk/client v0.1.0-alpha012
-	github.com/docker/go-sdk/config v0.1.0-alpha012
+	github.com/docker/go-sdk/client v0.1.0-alpha013
+	github.com/docker/go-sdk/config v0.1.0-alpha013
 	github.com/moby/go-archive v0.1.0
 	github.com/moby/moby/api v1.52.0
 	github.com/moby/moby/client v0.1.0
@@ -31,7 +31,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
-	github.com/docker/go-sdk/context v0.1.0-alpha012 // indirect
+	github.com/docker/go-sdk/context v0.1.0-alpha013 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/image/version.go
+++ b/image/version.go
@@ -3,7 +3,7 @@ package image
 import "github.com/docker/go-sdk/client"
 
 const (
-	version     = "0.1.0-alpha013"
+	version     = "0.1.0-alpha014"
 	moduleLabel = client.LabelBase + ".image"
 )
 

--- a/legacyadapters/go.mod
+++ b/legacyadapters/go.mod
@@ -6,7 +6,7 @@ replace github.com/docker/go-sdk/config => ../config
 
 require (
 	github.com/docker/cli v28.3.2+incompatible
-	github.com/docker/go-sdk/config v0.1.0-alpha012
+	github.com/docker/go-sdk/config v0.1.0-alpha013
 	github.com/moby/moby/api v1.52.0
 	github.com/stretchr/testify v1.10.0
 )

--- a/legacyadapters/version.go
+++ b/legacyadapters/version.go
@@ -1,7 +1,7 @@
 package legacyadapters
 
 const (
-	version = "0.1.0-alpha004"
+	version = "0.1.0-alpha005"
 )
 
 // Version returns the version of the legacyadapters package.

--- a/network/go.mod
+++ b/network/go.mod
@@ -10,7 +10,7 @@ replace (
 
 require (
 	github.com/containerd/errdefs v1.0.0
-	github.com/docker/go-sdk/client v0.1.0-alpha012
+	github.com/docker/go-sdk/client v0.1.0-alpha013
 	github.com/google/uuid v1.6.0
 	github.com/moby/moby/api v1.52.0
 	github.com/moby/moby/client v0.1.0
@@ -24,8 +24,8 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
-	github.com/docker/go-sdk/config v0.1.0-alpha012 // indirect
-	github.com/docker/go-sdk/context v0.1.0-alpha012 // indirect
+	github.com/docker/go-sdk/config v0.1.0-alpha013 // indirect
+	github.com/docker/go-sdk/context v0.1.0-alpha013 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/network/version.go
+++ b/network/version.go
@@ -3,7 +3,7 @@ package network
 import "github.com/docker/go-sdk/client"
 
 const (
-	version     = "0.1.0-alpha012"
+	version     = "0.1.0-alpha013"
 	moduleLabel = client.LabelBase + ".network"
 )
 

--- a/volume/go.mod
+++ b/volume/go.mod
@@ -10,7 +10,7 @@ replace (
 
 require (
 	github.com/containerd/errdefs v1.0.0
-	github.com/docker/go-sdk/client v0.1.0-alpha012
+	github.com/docker/go-sdk/client v0.1.0-alpha013
 	github.com/moby/moby/api v1.52.0
 	github.com/moby/moby/client v0.1.0
 	github.com/stretchr/testify v1.10.0
@@ -23,8 +23,8 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
-	github.com/docker/go-sdk/config v0.1.0-alpha012 // indirect
-	github.com/docker/go-sdk/context v0.1.0-alpha012 // indirect
+	github.com/docker/go-sdk/config v0.1.0-alpha013 // indirect
+	github.com/docker/go-sdk/context v0.1.0-alpha013 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/volume/version.go
+++ b/volume/version.go
@@ -3,7 +3,7 @@ package volume
 import "github.com/docker/go-sdk/client"
 
 const (
-	version     = "0.1.0-alpha004"
+	version     = "0.1.0-alpha005"
 	moduleLabel = client.LabelBase + ".volume"
 )
 


### PR DESCRIPTION
## Release Version Bump

**Bump type**: `prerelease`

### Version changes:

 - client: v0.1.0-alpha013
 - config: v0.1.0-alpha013
 - container: v0.1.0-alpha014
 - context: v0.1.0-alpha013
 - image: v0.1.0-alpha014
 - legacyadapters: v0.1.0-alpha005
 - network: v0.1.0-alpha013
 - volume: v0.1.0-alpha005

---
This PR was created automatically by the release workflow.
Merging this PR will trigger Phase 2 (automatic tagging and Go proxy update).