### PR TITLE
fix(release): handle GitHub PR number suffix in commit message check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
         #   - Squash merge: PR title is the subject line
         #   - Regular merge: PR title appears in the body
         #   - Rebase merge: original commit message is preserved
-        if echo "$COMMIT_MESSAGES" | grep -qE '^chore\((release|[a-z0-9_-]+)\): bump (module )?versions?[[:space:]]*$'; then
+        if echo "$COMMIT_MESSAGES" | grep -qE '^chore\((release|[a-z0-9_-]+)\): bump (module )?versions?([[:space:]]|\(#[0-9]+\))*$'; then
           echo "✅ Push contains a release commit — proceeding with tagging"
           echo "is_release=true" >> "$GITHUB_OUTPUT"
         else


### PR DESCRIPTION
## Summary

- Phase 2 auto-tagging was skipped because the commit message regex didn't account for GitHub's `(#NNN)` suffix on squash merge titles
- The squash merge of #144 produced `chore(release): bump module versions (#144)` which failed the `versions?[[:space:]]*$` pattern
- Updated regex to accept optional `(#NNN)` PR number suffix

## Test plan

- [ ] Merge this PR (squash)
- [ ] Re-run the Phase 2 workflow on the #144 merge commit, or verify the next push with version.go changes triggers tagging correctly