### PR TITLE
fix(config): wrap os.ErrNotExist and return empty config for missing ~/.docker

### DIFF
--- a/config/auth_test.go
+++ b/config/auth_test.go
@@ -203,7 +203,14 @@ func TestRegistryCredentialsForImage(t *testing.T) {
 
 	t.Run("config/not-found", func(t *testing.T) {
 		t.Setenv(EnvOverrideDir, filepath.Join("testdata", "missing"))
-		validateAuthForImage(t, "userpass.io/repo/image:tag", "", "", "", errors.New("file does not exist"))
+		// When the config directory does not exist, Load() returns an empty
+		// config (no error), so AuthConfigs returns no credentials.
+		authConfigs, err := AuthConfigs("userpass.io/repo/image:tag")
+		require.NoError(t, err)
+		for _, ac := range authConfigs {
+			require.Empty(t, ac.Username)
+			require.Empty(t, ac.Password)
+		}
 	})
 }
 
@@ -267,7 +274,12 @@ func TestRegistryCredentialsForHostname(t *testing.T) {
 
 	t.Run("config/not-found", func(t *testing.T) {
 		t.Setenv(EnvOverrideDir, filepath.Join("testdata", "missing"))
-		validateAuthForHostname(t, "userpass.io", "", "", errors.New("file does not exist"))
+		// When the config directory does not exist, Load() returns an empty
+		// config (no error), so AuthConfigForHostname returns empty results.
+		creds, err := AuthConfigForHostname("userpass.io")
+		require.NoError(t, err)
+		require.Empty(t, creds.Username)
+		require.Empty(t, creds.Password)
 	})
 }
 

--- a/config/load.go
+++ b/config/load.go
@@ -43,11 +43,15 @@ func getHomeDir() (string, error) {
 
 // Dir returns the directory the configuration file is stored in,
 // checking if the directory exists.
+//
+// When the directory does not exist the returned error wraps
+// [os.ErrNotExist] so that callers can detect the condition with
+// [errors.Is] or [os.IsNotExist].
 func Dir() (string, error) {
 	dir := os.Getenv(EnvOverrideDir)
 	if dir != "" {
-		if !fileExists(dir) {
-			return "", fmt.Errorf("file does not exist (%s)", dir)
+		if _, err := os.Stat(dir); err != nil {
+			return "", fmt.Errorf("config dir %s: %w", dir, err)
 		}
 		return dir, nil
 	}
@@ -58,23 +62,19 @@ func Dir() (string, error) {
 	}
 
 	configDir := filepath.Join(home, configFileDir)
-	if !fileExists(configDir) {
-		return "", fmt.Errorf("file does not exist (%s)", configDir)
+	if _, err := os.Stat(configDir); err != nil {
+		return "", fmt.Errorf("config dir %s: %w", configDir, err)
 	}
 
 	return configDir, nil
 }
 
-func fileExists(path string) bool {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return false
-	}
-
-	return true
-}
-
 // Filepath returns the path to the docker cli config file,
 // checking if the file exists.
+//
+// When the directory or file does not exist the returned error wraps
+// [os.ErrNotExist] so that callers can detect the condition with
+// [errors.Is] or [os.IsNotExist].
 func Filepath() (string, error) {
 	dir, err := Dir()
 	if err != nil {
@@ -82,8 +82,8 @@ func Filepath() (string, error) {
 	}
 
 	configFilePath := filepath.Join(dir, FileName)
-	if !fileExists(configFilePath) {
-		return "", fmt.Errorf("config file does not exist (%s)", configFilePath)
+	if _, err := os.Stat(configFilePath); err != nil {
+		return "", fmt.Errorf("config file %s: %w", configFilePath, err)
 	}
 
 	return configFilePath, nil
@@ -93,6 +93,11 @@ func Filepath() (string, error) {
 // 1. the DOCKER_AUTH_CONFIG environment variable, unmarshalling it into a Config
 // 2. the DOCKER_CONFIG environment variable, as the path to the config file
 // 3. else it will load the default config file, which is ~/.docker/config.json
+//
+// If the configuration directory or file does not exist, Load returns an
+// empty [Config] and a nil error.  This matches the behaviour of
+// [github.com/docker/cli/cli/config.Load] and allows callers to work on
+// systems where Docker has never been installed.
 func Load() (Config, error) {
 	if env := os.Getenv("DOCKER_AUTH_CONFIG"); env != "" {
 		var cfg Config
@@ -105,6 +110,9 @@ func Load() (Config, error) {
 	var cfg Config
 	p, err := Filepath()
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return cfg, nil
+		}
 		return cfg, fmt.Errorf("config path: %w", err)
 	}
 

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,7 +34,7 @@ func TestLoad(t *testing.T) {
 			setupHome(t, "testdata", "not-found")
 
 			cfg, err := Load()
-			require.ErrorContains(t, err, "file does not exist")
+			require.NoError(t, err, "Load should return empty config when ~/.docker does not exist")
 			require.Empty(t, cfg)
 		})
 
@@ -117,7 +118,7 @@ func TestDir(t *testing.T) {
 			setupHome(t, "testdata", "not-found")
 
 			dir, err := Dir()
-			require.ErrorContains(t, err, "file does not exist")
+			require.True(t, errors.Is(err, os.ErrNotExist), "error should wrap os.ErrNotExist, got: %v", err)
 			require.Empty(t, dir)
 		})
 	})
@@ -136,7 +137,7 @@ func TestDir(t *testing.T) {
 			setupDockerConfigs(t, "testdata", "not-found")
 
 			dir, err := Dir()
-			require.ErrorContains(t, err, "file does not exist")
+			require.True(t, errors.Is(err, os.ErrNotExist), "error should wrap os.ErrNotExist, got: %v", err)
 			require.Empty(t, dir)
 		})
 	})


### PR DESCRIPTION
## Summary

- `Dir()` and `Filepath()` now wrap `os.ErrNotExist` properly via `%w`, so callers using `errors.Is(err, os.ErrNotExist)` or `os.IsNotExist(err)` can detect missing config gracefully
- `Load()` returns an empty `Config` with nil error when the config dir/file doesn't exist, matching `docker/cli`'s `config.Load()` behavior
- Removes the now-unused `fileExists` helper

## Context

On systems where Docker has never been installed (e.g. a clean macOS laptop using Docker Sandboxes installed via Homebrew), `~/.docker/` does not exist. When `image.Pull()` runs, it calls `WithCredentialsFromConfig` → `config.AuthConfigs()` → `config.Load()` → `config.Filepath()` → `config.Dir()`, which returned a plain string error:

```
file does not exist (~/.docker)
```

Callers like `context.Current()` already had `os.IsNotExist(err)` checks to handle this case, but they never matched because the error was a formatted string, not a wrapped `os.ErrNotExist`.

After the user manually created `~/.docker/`, the next error was:

```
config file does not exist (~/.docker/config.json)
```

Same root cause — `Filepath()` also returned a string error instead of wrapping the underlying `os.Stat` error.

Reported via: https://docker.slack.com/archives/C09E0594URW/p1773413438983759

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Authored and posted by Claude