### PR TITLE
fix(image): map <token> credentials to IdentityToken in Pull

### DIFF
--- a/image/pull.go
+++ b/image/pull.go
@@ -87,10 +87,22 @@ func Pull(ctx context.Context, imageName string, opts ...PullOption) error {
 		pullOpts.client.Logger().Warn("failed to parse image reference, ServerAddress will be empty", "image", imageName, "error", err)
 	}
 
-	authConfig := registry.AuthConfig{
-		Username:      username,
-		Password:      password,
-		ServerAddress: imgRef.Registry,
+	// The Docker credential store convention uses "<token>" as the username
+	// to indicate the password is an identity/OAuth token, not a literal
+	// password. Map this to the IdentityToken field so the daemon handles
+	// it correctly (see docker/cli credentials/native_store.go).
+	var authConfig registry.AuthConfig
+	if username == "<token>" {
+		authConfig = registry.AuthConfig{
+			IdentityToken: password,
+			ServerAddress: imgRef.Registry,
+		}
+	} else {
+		authConfig = registry.AuthConfig{
+			Username:      username,
+			Password:      password,
+			ServerAddress: imgRef.Registry,
+		}
 	}
 
 	pullOpts.pullOptions.RegistryAuth, err = authconfig.Encode(authConfig)

--- a/image/pull_unit_test.go
+++ b/image/pull_unit_test.go
@@ -42,6 +42,34 @@ func TestPullRegistryAuth(t *testing.T) {
 	require.Equal(t, "myregistry.example.com", decoded.ServerAddress)
 }
 
+func TestPullRegistryAuth_TokenUsername(t *testing.T) {
+	mockCli := &errMockCli{}
+	sdk, err := sdkclient.New(context.TODO(), sdkclient.WithDockerAPI(mockCli))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	imageName := "docker/sandbox-templates:shell-docker"
+	err = Pull(ctx, imageName,
+		WithPullOptions(dockerclient.ImagePullOptions{}),
+		WithCredentialsFn(func(_ string) (string, string, error) {
+			return "<token>", "my-oauth-token", nil
+		}),
+		WithPullClient(sdk),
+	)
+	require.NoError(t, err)
+
+	// When username is "<token>", the token should be mapped to IdentityToken
+	// (not Username/Password), matching the Docker CLI credential store convention.
+	decoded, err := authconfig.Decode(mockCli.lastPullOptions.RegistryAuth)
+	require.NoError(t, err)
+	require.Empty(t, decoded.Username, "Username should be empty for token auth")
+	require.Empty(t, decoded.Password, "Password should be empty for token auth")
+	require.Equal(t, "my-oauth-token", decoded.IdentityToken)
+	require.Equal(t, "docker.io", decoded.ServerAddress)
+}
+
 func TestPull(t *testing.T) {
 	defaultPullOpts := []PullOption{WithPullOptions(dockerclient.ImagePullOptions{})}
 


### PR DESCRIPTION
### Problem

`image.Pull()` fails with `401 Unauthorized` when credentials are provided via `WithCredentialsFn` using the `<token>` username convention:

    failed to resolve image: failed to authorize: failed to fetch oauth token:
    unexpected status from GET request to https://auth.docker.io/token?...: 401 Unauthorized

### Root Cause

Since alpha014, `Pull()` sets `ServerAddress` from the image reference. When `ServerAddress` is set, the daemon's credential resolver matches the host and forwards the credentials to containerd's transfer service.

`Pull()` puts `<token>` into `AuthConfig.Username` and the OAuth token into `AuthConfig.Password`. Containerd interprets `Username`+`Secret` as basic auth credentials and sends `<token>:JWT` to
Docker Hub's token endpoint, which rejects it.

### Background

The `<token>` username convention originates from the [docker-credential-helpers protocol](https://github.com/docker/docker-credential-helpers), which only has `Username`/`Secret`/`ServerURL` fields — no `IdentityToken`. The Docker CLI's [native credential store](https://github.com/docker/cli/blob/master/cli/config/credentials/native_store.go#L132-L136) maps `<token>` back to
`IdentityToken` on retrieval:

    if creds.Username == tokenUsername {
        ret.IdentityToken = creds.Secret
    } else {
        ret.Password = creds.Secret
        ret.Username = creds.Username
    }

The go-sdk's `WithCredentialsFn` has the same `(username, password, error)` signature as the credential helpers protocol, so it needs the same mapping.

### Fix

When `credentialsFn` returns `"<token>"` as the username, map the password to `AuthConfig.IdentityToken` instead of `AuthConfig.Password`:

    if username == "<token>" {
        authConfig = registry.AuthConfig{
            IdentityToken: password,
            ServerAddress: imgRef.Registry,
        }
    }

This ensures the daemon receives a properly structured auth config, matching the Docker CLI's behaviour.

### Testing

- Added `TestPullRegistryAuth_TokenUsername` verifying `<token>` credentials are mapped to `IdentityToken` with empty `Username`/`Password`
- Verified end-to-end with `sbx` CLI: `--pull always` (which uses `WithAlwaysPull` + `WithCredentialsFn`) now works correctly for both cached and uncached images