### PR TITLE
chore(container): bump version

### DIFF
--- a/container/version.go
+++ b/container/version.go
@@ -3,7 +3,7 @@ package container
 import "github.com/docker/go-sdk/client"
 
 const (
-	version     = "0.1.0-alpha014"
+	version     = "0.1.0-alpha015"
 	moduleLabel = client.LabelBase + ".container"
 )
 


### PR DESCRIPTION
## Release Version Bump

**Bump type**: `prerelease`

### Version changes:
- container: v0.1.0-alpha015

This PR was created for a workflow run whose `gh pr create` step was blocked by a now-fixed permission setting