### PR TITLE
chore(ci): declare per-job contents read on the sonar workflows

### DIFF
--- a/.github/workflows/sonar-bulk-operations.yml
+++ b/.github/workflows/sonar-bulk-operations.yml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   bulk-operation:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/sonar-create-project.yml
+++ b/.github/workflows/sonar-create-project.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   create-project:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/sonar-delete-project.yml
+++ b/.github/workflows/sonar-delete-project.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   delete-project:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
The three Sonar admin workflows (`sonar-bulk-operations.yml`, `sonar-create-project.yml`, `sonar-delete-project.yml`) are manual (`workflow_dispatch`) actions. Each runs `actions/checkout` then invokes `.github/scripts/sonar-manager.sh` using `secrets.SONAR_TOKEN`. The default `GITHUB_TOKEN` is only used for the checkout step.

Match the per-job permissions pattern already used by `ci.yml`, `ci-test-go.yml`, `ci-lint-go.yml` in this repo (per-job `contents: read`).