### PR TITLE
fix(wait): bound exec attempts to PollInterval timeout and add WithRetryOnError

### DIFF
--- a/container/wait/exec.go
+++ b/container/wait/exec.go
@@ -24,6 +24,7 @@ type ExecStrategy struct {
 	ExitCodeMatcher func(exitCode int) bool
 	ResponseMatcher func(body io.Reader) bool
 	PollInterval    time.Duration
+	retryOnError    bool
 }
 
 // NewExecStrategy constructs an Exec strategy ...
@@ -68,6 +69,13 @@ func (ws *ExecStrategy) WithPollInterval(pollInterval time.Duration) *ExecStrate
 	return ws
 }
 
+// WithRetryOnError configures the strategy to retry when target.Exec returns an error,
+// instead of failing immediately. The strategy still stops on overall context cancellation.
+func (ws *ExecStrategy) WithRetryOnError() *ExecStrategy {
+	ws.retryOnError = true
+	return ws
+}
+
 // ForExec is a convenience method to assign ExecStrategy
 func ForExec(cmd []string) *ExecStrategy {
 	return NewExecStrategy(cmd)
@@ -109,12 +117,16 @@ func (ws *ExecStrategy) WaitUntilReady(ctx context.Context, target StrategyTarge
 		case <-time.After(ws.PollInterval):
 			execCtx, execCancel := context.WithTimeout(ctx, ws.PollInterval)
 			exitCode, resp, err := target.Exec(execCtx, ws.cmd, exec.Multiplexed())
+			execTimedOut := execCtx.Err() != nil
 			execCancel()
 			if err != nil {
 				if ctx.Err() != nil {
 					return ctx.Err()
 				}
-				if execCtx.Err() != nil {
+				if execTimedOut {
+					continue
+				}
+				if ws.retryOnError {
 					continue
 				}
 				return err

--- a/container/wait/exec.go
+++ b/container/wait/exec.go
@@ -107,8 +107,16 @@ func (ws *ExecStrategy) WaitUntilReady(ctx context.Context, target StrategyTarge
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-time.After(ws.PollInterval):
-			exitCode, resp, err := target.Exec(ctx, ws.cmd, exec.Multiplexed())
+			execCtx, execCancel := context.WithTimeout(ctx, ws.PollInterval)
+			exitCode, resp, err := target.Exec(execCtx, ws.cmd, exec.Multiplexed())
+			execCancel()
 			if err != nil {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				if execCtx.Err() != nil {
+					continue
+				}
 				return err
 			}
 			if !ws.ExitCodeMatcher(exitCode) {

--- a/container/wait/exec_test.go
+++ b/container/wait/exec_test.go
@@ -167,3 +167,27 @@ func TestExecStrategyWaitUntilReady_ExecTimeoutDeadlineExceeded(t *testing.T) {
 	err := wg.WaitUntilReady(context.Background(), target)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
+
+func TestExecStrategyWaitUntilReady_RetryOnError(t *testing.T) {
+	target := mockExecTarget{
+		failure:      errors.New("transient exec error"),
+		successAfter: time.Now().Add(time.Second),
+	}
+	wg := wait.NewExecStrategy([]string{"true"}).
+		WithPollInterval(100 * time.Millisecond).
+		WithTimeout(5 * time.Second).
+		WithRetryOnError()
+	err := wg.WaitUntilReady(context.Background(), target)
+	require.NoError(t, err)
+}
+
+func TestExecStrategyWaitUntilReady_FailOnError(t *testing.T) {
+	execErr := errors.New("exec failed")
+	target := mockExecTarget{
+		failure: execErr,
+	}
+	wg := wait.NewExecStrategy([]string{"true"}).
+		WithTimeout(5 * time.Second)
+	err := wg.WaitUntilReady(context.Background(), target)
+	require.ErrorIs(t, err, execErr)
+}

--- a/container/wait/exec_test.go
+++ b/container/wait/exec_test.go
@@ -43,19 +43,22 @@ func (st mockExecTarget) Logs(_ context.Context) (io.ReadCloser, error) {
 }
 
 func (st mockExecTarget) Exec(ctx context.Context, _ []string, _ ...exec.ProcessOption) (int, io.Reader, error) {
-	time.Sleep(st.waitDuration)
-
 	var reader io.Reader
 	if st.response != "" {
 		reader = bytes.NewReader([]byte(st.response))
 	}
 
-	if err := ctx.Err(); err != nil {
-		return st.exitCode, reader, err
+	// Return success immediately once successAfter has passed, without sleeping.
+	if !st.successAfter.IsZero() && time.Now().After(st.successAfter) {
+		return 0, reader, nil
 	}
 
-	if !st.successAfter.IsZero() && time.Now().After(st.successAfter) {
-		return 0, reader, st.failure
+	if st.waitDuration > 0 {
+		select {
+		case <-time.After(st.waitDuration):
+		case <-ctx.Done():
+			return st.exitCode, nil, ctx.Err()
+		}
 	}
 
 	return st.exitCode, reader, st.failure
@@ -137,4 +140,30 @@ func TestExecStrategyWaitUntilReady_withExitCode(t *testing.T) {
 	wg.WithTimeout(time.Second * 2)
 	err = wg.WaitUntilReady(context.Background(), target)
 	require.Errorf(t, err, "Expected strategy to timeout out")
+}
+
+func TestExecStrategyWaitUntilReady_ExecPerPollTimeout(t *testing.T) {
+	pollInterval := 100 * time.Millisecond
+	target := mockExecTarget{
+		exitCode:     1,
+		waitDuration: 3 * pollInterval,            // exec takes longer than one poll tick
+		successAfter: time.Now().Add(time.Second), // after 1s exec returns quickly
+	}
+	wg := wait.NewExecStrategy([]string{"true"}).
+		WithPollInterval(pollInterval).
+		WithTimeout(5 * time.Second)
+	err := wg.WaitUntilReady(context.Background(), target)
+	require.NoError(t, err)
+}
+
+func TestExecStrategyWaitUntilReady_ExecTimeoutDeadlineExceeded(t *testing.T) {
+	pollInterval := 100 * time.Millisecond
+	target := mockExecTarget{
+		waitDuration: 10 * pollInterval, // always hangs longer than PollInterval
+	}
+	wg := wait.NewExecStrategy([]string{"true"}).
+		WithPollInterval(pollInterval).
+		WithTimeout(500 * time.Millisecond)
+	err := wg.WaitUntilReady(context.Background(), target)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }


### PR DESCRIPTION
## Summary

- **Per-exec timeout**: Each `target.Exec` call in `ExecStrategy.WaitUntilReady` now runs under its own child context bounded by `ws.PollInterval`. A hanging exec is cancelled after one poll tick and the strategy retries, instead of blocking until the entire strategy timeout is exhausted.
- **`WithRetryOnError`**: New builder method on `ExecStrategy`. When set, a transient error from `target.Exec` triggers a retry rather than immediately failing the wait strategy. The overall context deadline still terminates the strategy.

Fixes the readiness-attempt issue identified in docker/sandboxes#3680 at the source in go-sdk.

## Test plan

- [ ] `TestExecStrategyWaitUntilReady_ExecPerPollTimeout` — strategy retries after per-exec timeout, eventually succeeds
- [ ] `TestExecStrategyWaitUntilReady_ExecTimeoutDeadlineExceeded` — overall deadline still propagates when exec always hangs
- [ ] `TestExecStrategyWaitUntilReady_RetryOnError` — `WithRetryOnError` survives transient errors and eventually succeeds
- [ ] `TestExecStrategyWaitUntilReady_FailOnError` — without `WithRetryOnError`, first exec error fails immediately (existing behaviour preserved)
- [ ] All existing exec wait tests continue to pass

```
go test ./container/wait/... -run TestExec -timeout 60s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)