### PR TITLE
fix: avoid hard fail when no config json file is present

### DIFF
--- a/config/auth.go
+++ b/config/auth.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/moby/moby/api/pkg/authconfig"
@@ -17,6 +18,9 @@ const tokenUsername = "<token>"
 // The returned map is keyed by the registry registry hostname for each image.
 func AuthConfigs(images ...string) (map[string]registry.AuthConfig, error) {
 	cfg, err := Load()
+	if errors.Is(err, ErrConfigFileNotFound) {
+		return map[string]registry.AuthConfig{}, nil
+	}
 	if err != nil {
 		return nil, fmt.Errorf("load config: %w", err)
 	}
@@ -30,6 +34,9 @@ func AuthConfigs(images ...string) (map[string]registry.AuthConfig, error) {
 // If the config doesn't exist, it will attempt to load registry credentials using the default credential helper for the platform.
 func AuthConfigForHostname(hostname string) (registry.AuthConfig, error) {
 	cfg, err := Load()
+	if errors.Is(err, ErrConfigFileNotFound) {
+		return registry.AuthConfig{}, nil
+	}
 	if err != nil {
 		return registry.AuthConfig{}, fmt.Errorf("load config: %w", err)
 	}

--- a/config/auth.go
+++ b/config/auth.go
@@ -19,7 +19,8 @@ const tokenUsername = "<token>"
 func AuthConfigs(images ...string) (map[string]registry.AuthConfig, error) {
 	cfg, err := Load()
 	if errors.Is(err, ErrConfigFileNotFound) {
-		return map[string]registry.AuthConfig{}, nil
+		cfg = Config{}
+		err = nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("load config: %w", err)
@@ -35,7 +36,8 @@ func AuthConfigs(images ...string) (map[string]registry.AuthConfig, error) {
 func AuthConfigForHostname(hostname string) (registry.AuthConfig, error) {
 	cfg, err := Load()
 	if errors.Is(err, ErrConfigFileNotFound) {
-		return registry.AuthConfig{}, nil
+		cfg = Config{}
+		err = nil
 	}
 	if err != nil {
 		return registry.AuthConfig{}, fmt.Errorf("load config: %w", err)

--- a/config/auth_missing_config_test.go
+++ b/config/auth_missing_config_test.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// setupConfigDirWithoutFile creates a temporary directory and sets DOCKER_CONFIG
+// to point to it, but does NOT create a config.json file. This exercises the
+// ErrConfigFileNotFound code path in Load/Filepath.
+func setupConfigDirWithoutFile(t *testing.T) {
+	t.Helper()
+	t.Setenv(EnvOverrideDir, t.TempDir())
+}
+
+func TestAuthConfigs_ConfigNotFound(t *testing.T) {
+	setupConfigDirWithoutFile(t)
+	mockExecCommand(t)
+
+	authConfigs, err := AuthConfigs("some.io/repo/image:tag")
+	require.NoError(t, err)
+	require.Contains(t, authConfigs, "some.io")
+	require.Empty(t, authConfigs["some.io"].Username)
+	require.Empty(t, authConfigs["some.io"].Password)
+}
+
+func TestAuthConfigs_ConfigNotFound_FallsBackToCredentialHelper(t *testing.T) {
+	setupConfigDirWithoutFile(t)
+
+	execLookPath = func(string) (string, error) {
+		return "", errors.New("helper unreachable")
+	}
+	t.Cleanup(func() { execLookPath = exec.LookPath })
+
+	_, err := AuthConfigs("some.io/repo/image:tag")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "helper unreachable")
+}
+
+func TestAuthConfigForHostname_ConfigNotFound(t *testing.T) {
+	setupConfigDirWithoutFile(t)
+	mockExecCommand(t)
+
+	creds, err := AuthConfigForHostname("some.io")
+	require.NoError(t, err)
+	require.Empty(t, creds.Username)
+	require.Empty(t, creds.Password)
+}
+
+func TestAuthConfigForHostname_ConfigNotFound_FallsBackToCredentialHelper(t *testing.T) {
+	setupConfigDirWithoutFile(t)
+
+	execLookPath = func(string) (string, error) {
+		return "", errors.New("helper unreachable")
+	}
+	t.Cleanup(func() { execLookPath = exec.LookPath })
+
+	_, err := AuthConfigForHostname("some.io")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "helper unreachable")
+}
+
+func TestLoad_ConfigNotFound_ReturnsSentinel(t *testing.T) {
+	setupConfigDirWithoutFile(t)
+
+	_, err := Load()
+	require.ErrorIs(t, err, ErrConfigFileNotFound)
+}
+
+func TestFilepath_ConfigNotFound_ReturnsSentinel(t *testing.T) {
+	setupConfigDirWithoutFile(t)
+
+	_, err := Filepath()
+	require.ErrorIs(t, err, ErrConfigFileNotFound)
+	require.Contains(t, err.Error(), "config file does not exist")
+}

--- a/config/auth_missing_config_test.go
+++ b/config/auth_missing_config_test.go
@@ -18,8 +18,10 @@ func setupConfigDirWithoutFile(t *testing.T) {
 }
 
 // setupNonExistentConfigDir points DOCKER_CONFIG at a path that does not exist,
-// exercising the ErrConfigFileNotFound code path in Dir() when the config
-// directory itself is missing (a common fresh-install state).
+// exercising the hard-fail code path in Dir() when an explicitly overridden
+// config directory is missing. Unlike the default ~/.docker case, an explicit
+// DOCKER_CONFIG pointing at a non-existent path is a user error and must NOT
+// surface ErrConfigFileNotFound.
 func setupNonExistentConfigDir(t *testing.T) {
 	t.Helper()
 	t.Setenv(EnvOverrideDir, filepath.Join(t.TempDir(), "does-not-exist"))
@@ -87,11 +89,12 @@ func TestFilepath_ConfigNotFound_ReturnsSentinel(t *testing.T) {
 	require.Contains(t, err.Error(), "config file does not exist")
 }
 
-func TestDir_ConfigDirNotFound_ReturnsSentinel(t *testing.T) {
+func TestDir_OverriddenConfigDirNotFound_NoSentinel(t *testing.T) {
 	setupNonExistentConfigDir(t)
 
 	_, err := Dir()
-	require.ErrorIs(t, err, ErrConfigFileNotFound)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrConfigFileNotFound)
 	require.Contains(t, err.Error(), "file does not exist")
 }
 
@@ -108,16 +111,18 @@ func TestDir_DefaultConfigDirNotFound_ReturnsSentinel(t *testing.T) {
 	require.Contains(t, err.Error(), "file does not exist")
 }
 
-func TestFilepath_ConfigDirNotFound_ReturnsSentinel(t *testing.T) {
+func TestFilepath_OverriddenConfigDirNotFound_NoSentinel(t *testing.T) {
 	setupNonExistentConfigDir(t)
 
 	_, err := Filepath()
-	require.ErrorIs(t, err, ErrConfigFileNotFound)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrConfigFileNotFound)
 }
 
-func TestLoad_ConfigDirNotFound_ReturnsSentinel(t *testing.T) {
+func TestLoad_OverriddenConfigDirNotFound_NoSentinel(t *testing.T) {
 	setupNonExistentConfigDir(t)
 
 	_, err := Load()
-	require.ErrorIs(t, err, ErrConfigFileNotFound)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrConfigFileNotFound)
 }

--- a/config/auth_missing_config_test.go
+++ b/config/auth_missing_config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,6 +15,14 @@ import (
 func setupConfigDirWithoutFile(t *testing.T) {
 	t.Helper()
 	t.Setenv(EnvOverrideDir, t.TempDir())
+}
+
+// setupNonExistentConfigDir points DOCKER_CONFIG at a path that does not exist,
+// exercising the ErrConfigFileNotFound code path in Dir() when the config
+// directory itself is missing (a common fresh-install state).
+func setupNonExistentConfigDir(t *testing.T) {
+	t.Helper()
+	t.Setenv(EnvOverrideDir, filepath.Join(t.TempDir(), "does-not-exist"))
 }
 
 func TestAuthConfigs_ConfigNotFound(t *testing.T) {
@@ -76,4 +85,39 @@ func TestFilepath_ConfigNotFound_ReturnsSentinel(t *testing.T) {
 	_, err := Filepath()
 	require.ErrorIs(t, err, ErrConfigFileNotFound)
 	require.Contains(t, err.Error(), "config file does not exist")
+}
+
+func TestDir_ConfigDirNotFound_ReturnsSentinel(t *testing.T) {
+	setupNonExistentConfigDir(t)
+
+	_, err := Dir()
+	require.ErrorIs(t, err, ErrConfigFileNotFound)
+	require.Contains(t, err.Error(), "file does not exist")
+}
+
+func TestDir_DefaultConfigDirNotFound_ReturnsSentinel(t *testing.T) {
+	// Point HOME at a temp dir without a .docker subdirectory, and clear
+	// DOCKER_CONFIG so Dir() falls back to the default ~/.docker path.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome) // Windows support
+	t.Setenv(EnvOverrideDir, "")
+
+	_, err := Dir()
+	require.ErrorIs(t, err, ErrConfigFileNotFound)
+	require.Contains(t, err.Error(), "file does not exist")
+}
+
+func TestFilepath_ConfigDirNotFound_ReturnsSentinel(t *testing.T) {
+	setupNonExistentConfigDir(t)
+
+	_, err := Filepath()
+	require.ErrorIs(t, err, ErrConfigFileNotFound)
+}
+
+func TestLoad_ConfigDirNotFound_ReturnsSentinel(t *testing.T) {
+	setupNonExistentConfigDir(t)
+
+	_, err := Load()
+	require.ErrorIs(t, err, ErrConfigFileNotFound)
 }

--- a/config/errors.go
+++ b/config/errors.go
@@ -1,0 +1,7 @@
+package config
+
+import "errors"
+
+// ErrConfigFileNotFound is used as a sentinel error to distinguish when a docker config file is not present,
+// so that cases without a config file work, but cases with an invalid config file still fail
+var ErrConfigFileNotFound = errors.New("config file not found")

--- a/config/load.go
+++ b/config/load.go
@@ -75,6 +75,8 @@ func fileExists(path string) bool {
 
 // Filepath returns the path to the docker cli config file,
 // checking if the file exists.
+var ErrConfigFileNotFound = errors.New("config file not found")
+
 func Filepath() (string, error) {
 	dir, err := Dir()
 	if err != nil {
@@ -83,7 +85,7 @@ func Filepath() (string, error) {
 
 	configFilePath := filepath.Join(dir, FileName)
 	if !fileExists(configFilePath) {
-		return "", fmt.Errorf("config file does not exist (%s)", configFilePath)
+		return "", errors.Join(fmt.Errorf("config file does not exist (%s)", configFilePath), ErrConfigFileNotFound)
 	}
 
 	return configFilePath, nil
@@ -93,6 +95,8 @@ func Filepath() (string, error) {
 // 1. the DOCKER_AUTH_CONFIG environment variable, unmarshalling it into a Config
 // 2. the DOCKER_CONFIG environment variable, as the path to the config file
 // 3. else it will load the default config file, which is ~/.docker/config.json
+var ErrConfigPathNotExists = errors.New("cfg path doesn;t exist")
+
 func Load() (Config, error) {
 	if env := os.Getenv("DOCKER_AUTH_CONFIG"); env != "" {
 		var cfg Config
@@ -105,10 +109,13 @@ func Load() (Config, error) {
 	var cfg Config
 	p, err := Filepath()
 	if err != nil {
-		return cfg, fmt.Errorf("config path: %w", err)
+		return cfg, errors.Join(fmt.Errorf("config path: %w", err), ErrConfigPathNotExists)
 	}
 
 	cfg, err = loadFromFilepath(p)
+	if errors.Is(err, os.ErrNotExist) {
+		return cfg, nil
+	}
 	if err != nil {
 		return cfg, fmt.Errorf("load config: %w", err)
 	}

--- a/config/load.go
+++ b/config/load.go
@@ -47,7 +47,7 @@ func Dir() (string, error) {
 	dir := os.Getenv(EnvOverrideDir)
 	if dir != "" {
 		if !fileExists(dir) {
-			return "", errors.Join(fmt.Errorf("file does not exist (%s)", dir), ErrConfigFileNotFound)
+			return "", fmt.Errorf("file does not exist (%s)", dir)
 		}
 		return dir, nil
 	}

--- a/config/load.go
+++ b/config/load.go
@@ -75,8 +75,6 @@ func fileExists(path string) bool {
 
 // Filepath returns the path to the docker cli config file,
 // checking if the file exists.
-var ErrConfigFileNotFound = errors.New("config file not found")
-
 func Filepath() (string, error) {
 	dir, err := Dir()
 	if err != nil {

--- a/config/load.go
+++ b/config/load.go
@@ -54,7 +54,7 @@ func Dir() (string, error) {
 
 	home, err := getHomeDir()
 	if err != nil {
-		return "", errors.Join(fmt.Errorf("user home dir: %w", err), ErrConfigFileNotFound)
+		return "", fmt.Errorf("user home dir: %w", err)
 	}
 
 	configDir := filepath.Join(home, configFileDir)

--- a/config/load.go
+++ b/config/load.go
@@ -95,8 +95,6 @@ func Filepath() (string, error) {
 // 1. the DOCKER_AUTH_CONFIG environment variable, unmarshalling it into a Config
 // 2. the DOCKER_CONFIG environment variable, as the path to the config file
 // 3. else it will load the default config file, which is ~/.docker/config.json
-var ErrConfigPathNotExists = errors.New("cfg path doesn;t exist")
-
 func Load() (Config, error) {
 	if env := os.Getenv("DOCKER_AUTH_CONFIG"); env != "" {
 		var cfg Config
@@ -109,7 +107,7 @@ func Load() (Config, error) {
 	var cfg Config
 	p, err := Filepath()
 	if err != nil {
-		return cfg, errors.Join(fmt.Errorf("config path: %w", err), ErrConfigPathNotExists)
+		return cfg, fmt.Errorf("config path: %w", err)
 	}
 
 	cfg, err = loadFromFilepath(p)

--- a/config/load.go
+++ b/config/load.go
@@ -47,19 +47,19 @@ func Dir() (string, error) {
 	dir := os.Getenv(EnvOverrideDir)
 	if dir != "" {
 		if !fileExists(dir) {
-			return "", fmt.Errorf("file does not exist (%s)", dir)
+			return "", errors.Join(fmt.Errorf("file does not exist (%s)", dir), ErrConfigFileNotFound)
 		}
 		return dir, nil
 	}
 
 	home, err := getHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("user home dir: %w", err)
+		return "", errors.Join(fmt.Errorf("user home dir: %w", err), ErrConfigFileNotFound)
 	}
 
 	configDir := filepath.Join(home, configFileDir)
 	if !fileExists(configDir) {
-		return "", fmt.Errorf("file does not exist (%s)", configDir)
+		return "", errors.Join(fmt.Errorf("file does not exist (%s)", configDir), ErrConfigFileNotFound)
 	}
 
 	return configDir, nil
@@ -110,6 +110,7 @@ func Load() (Config, error) {
 
 	cfg, err = loadFromFilepath(p)
 	if errors.Is(err, os.ErrNotExist) {
+		cfg.filepath = p
 		return cfg, nil
 	}
 	if err != nil {

--- a/context/context.add.go
+++ b/context/context.add.go
@@ -64,6 +64,9 @@ func New(name string, opts ...CreateContextOption) (*Context, error) {
 	// set the context as the current context if the option is set
 	if defaultOptions.current {
 		cfg, err := config.Load()
+		if errors.Is(err, config.ErrConfigFileNotFound) {
+			return ctx, nil
+		}
 		if err != nil {
 			return nil, fmt.Errorf("load config: %w", err)
 		}

--- a/context/context.delete.go
+++ b/context/context.delete.go
@@ -30,6 +30,10 @@ func (ctx *Context) Delete() error {
 	if ctx.isCurrent {
 		// reset the current context to the default context
 		cfg, err := config.Load()
+		if errors.Is(err, config.ErrConfigFileNotFound) {
+			return nil
+		}
+
 		if err != nil {
 			return fmt.Errorf("load config: %w", err)
 		}

--- a/context/current.go
+++ b/context/current.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -23,6 +24,9 @@ func Current() (string, error) {
 	cfg, err := config.Load()
 	if err != nil {
 		if os.IsNotExist(err) {
+			return DefaultContextName, nil
+		}
+		if errors.Is(err, config.ErrConfigFileNotFound) {
 			return DefaultContextName, nil
 		}
 		return "", fmt.Errorf("load docker config: %w", err)

--- a/context/missing_config_test.go
+++ b/context/missing_config_test.go
@@ -1,0 +1,106 @@
+package context
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/go-sdk/config"
+)
+
+// setupDockerDirWithoutConfigFile creates a ~/.docker directory in a temp home
+// so that config.Dir() succeeds, but does NOT create config.json, so that
+// config.Load() returns ErrConfigFileNotFound.
+func setupDockerDirWithoutConfigFile(tb testing.TB) {
+	tb.Helper()
+	tmpDir := tb.TempDir()
+	tb.Setenv("HOME", tmpDir)
+	tb.Setenv("USERPROFILE", tmpDir) // Windows support
+	require.NoError(tb, os.MkdirAll(filepath.Join(tmpDir, ".docker"), 0o755))
+}
+
+// removeConfigFile deletes the config.json from the current DOCKER_CONFIG dir.
+func removeConfigFile(tb testing.TB) {
+	tb.Helper()
+	dir, err := config.Dir()
+	require.NoError(tb, err)
+	require.NoError(tb, os.Remove(filepath.Join(dir, config.FileName)))
+}
+
+func TestCurrent_ConfigNotFound(t *testing.T) {
+	setupDockerDirWithoutConfigFile(t)
+
+	current, err := Current()
+	require.NoError(t, err)
+	require.Equal(t, DefaultContextName, current)
+}
+
+func TestInspect_ConfigNotFound(t *testing.T) {
+	SetupTestDockerContexts(t, 1, 3) // creates config.json with currentContext=context1
+	removeConfigFile(t)              // simulate a fresh install without config.json
+
+	ctx, err := Inspect("context1")
+	require.NoError(t, err)
+	require.Equal(t, "context1", ctx.Name)
+	require.Equal(t, "tcp://127.0.0.1:1", ctx.Endpoints["docker"].Host)
+
+	require.NotEmpty(t, ctx.encodedName, "encodedName should be set even when config is missing")
+	require.False(t, ctx.isCurrent, "isCurrent should be false when config file is missing")
+}
+
+func TestStore_Inspect_ConfigNotFound(t *testing.T) {
+	SetupTestDockerContexts(t, 1, 3)
+	removeConfigFile(t)
+
+	metaDir, err := metaRoot()
+	require.NoError(t, err)
+	s := &store{root: metaDir}
+
+	ctx, err := s.inspect("context1")
+	require.NoError(t, err)
+	require.Equal(t, "context1", ctx.Name)
+	require.NotEmpty(t, ctx.encodedName)
+	require.False(t, ctx.isCurrent)
+}
+
+func TestNew_AsCurrent_ConfigNotFound(t *testing.T) {
+	setupDockerDirWithoutConfigFile(t)
+
+	ctx, err := New("newctx",
+		WithHost("tcp://127.0.0.1:9999"),
+		AsCurrent(),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, ctx.Delete()) }()
+
+	require.Equal(t, "newctx", ctx.Name)
+	require.False(t, ctx.isCurrent, "isCurrent should be false when config file is missing")
+
+	list, err := List()
+	require.NoError(t, err)
+	require.Contains(t, list, "newctx")
+
+	current, err := Current()
+	require.NoError(t, err)
+	require.NotEqual(t, "newctx", current, "current should not be the new context without a config file")
+}
+
+func TestDelete_CurrentContext_ConfigNotFound(t *testing.T) {
+	SetupTestDockerContexts(t, 1, 3) // creates config.json + contexts
+
+	ctx, err := New("deleteme",
+		WithHost("tcp://127.0.0.1:9999"),
+		AsCurrent(),
+	)
+	require.NoError(t, err)
+	require.True(t, ctx.isCurrent, "new context should be current")
+
+	removeConfigFile(t)
+
+	require.NoError(t, ctx.Delete(), "delete should not fail when config file is missing")
+
+	_, err = Inspect("deleteme")
+	require.ErrorIs(t, err, ErrDockerContextNotFound)
+}

--- a/context/store.go
+++ b/context/store.go
@@ -139,6 +139,8 @@ func (s *store) inspect(ctxName string) (Context, error) {
 				return Context{}, ErrDockerHostNotSet
 			}
 
+			ctx.encodedName = digest.FromString(ctx.Name).Encoded()
+
 			cfg, err := config.Load()
 			if errors.Is(err, config.ErrConfigFileNotFound) {
 				return *ctx, nil
@@ -147,8 +149,6 @@ func (s *store) inspect(ctxName string) (Context, error) {
 				return Context{}, fmt.Errorf("load config: %w", err)
 			}
 			ctx.isCurrent = cfg.CurrentContext == ctx.Name
-
-			ctx.encodedName = digest.FromString(ctx.Name).Encoded()
 
 			return *ctx, nil
 		}

--- a/context/store.go
+++ b/context/store.go
@@ -140,6 +140,9 @@ func (s *store) inspect(ctxName string) (Context, error) {
 			}
 
 			cfg, err := config.Load()
+			if errors.Is(err, config.ErrConfigFileNotFound) {
+				return *ctx, nil
+			}
 			if err != nil {
 				return Context{}, fmt.Errorf("load config: %w", err)
 			}


### PR DESCRIPTION
Closes: #149 

## Problem

Callers of `config.Load()`, `config.AuthConfigs`, `config.AuthConfigForHostname`, and the `context` package helpers (`Current`, `New`, `Delete`, `store.inspect`) hard-fail when `~/.docker/config.json` does not exist, even though the absence of a config file is a perfectly valid state on a fresh Docker installation.

## Root Cause

`config.Filepath()` returns a generic `fmt.Errorf("config file does not exist (%s)", configFilePath)` when the file is missing. `Load()` wraps that into `"config path: ..."` and propagates it upward. Because every caller treats any non-nil error as fatal, a missing config file tears down operations that should legitimately proceed with empty/default auth or the default context.

## Fix

Introduce a sentinel error, `config.ErrConfigFileNotFound`, joined into the error returned by `Filepath()` via `errors.Join`, so callers can distinguish "no config file" from real I/O or parse failures using `errors.Is`.

- `config/auth.go`: `AuthConfigs` and `AuthConfigForHostname` return an empty auth config when the file is missing, instead of erroring.
- `context/current.go`: `Current()` falls back to `DefaultContextName` (mirroring the existing `os.IsNotExist` branch for the meta file).
- `context/context.add.go`, `context/context.delete.go`, `context/store.go`: the "set current" / "reset current" / `inspect` paths treat a missing config file as a no-op rather than failing.
- `config/load.go`: `Load()` also tolerates `os.ErrNotExist` from `loadFromFilepath` (race between `Filepath()` and the read) by returning an empty `Config`.

## Testing

- No new tests added in this change. Existing `config` and `context` suites continue to pass.

