### PR TITLE
fix(docs): use io.Copy in the get logs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ package main
 import (
 	"context"
 	"os"
+	"io"
 
-	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-sdk/container"
 	"github.com/docker/go-sdk/container/wait"
 )
@@ -149,7 +149,7 @@ func main() {
 		panic(err)
 	}
 
-	stdcopy.StdCopy(os.Stdout, os.Stderr, logs)
+	io.Copy(os.Stdout, logs)
 
 	err = ctr.Terminate(context.Background())
 	if err != nil {


### PR DESCRIPTION
Closes: #160 

## Problem

The "get logs" example in the README copied the log stream using `stdcopy.StdCopy(os.Stdout, os.Stderr, logs)`, pulling in `github.com/docker/docker/pkg/stdcopy`. Readers following the example would either see garbled output or need an extra dependency that the SDK does not actually require for consuming `ctr.Logs()`.

## Root Cause

`stdcopy.StdCopy` decodes Docker's multiplexed stream format (an 8-byte header per frame carrying the stream type and payload length). The reader returned by `ctr.Logs()` is not in that multiplexed format, so feeding it to `stdcopy.StdCopy` results in an error, or no output if not handling the error.

## Fix

- `README.md`: replace the `github.com/docker/docker/pkg/stdcopy` import with the standard library `io` package, and copy the logs with `io.Copy(os.Stdout, logs)`.

## Testing

- Documentation-only change; no tests affected. The updated example compiles and prints the container log output as expected.